### PR TITLE
DFU: Fix wTotalLength in Configuration Descriptor

### DIFF
--- a/firmware/bootloader/bootloader.cpp
+++ b/firmware/bootloader/bootloader.cpp
@@ -116,7 +116,7 @@ static const u8 dfu_descriptors[] = {
 // configuration
 	0x09,
 	DESC_CONFIGURATION,
-	LE_WORD(0x20),  		// wTotalLength
+	LE_WORD(0x1B),  		// wTotalLength
 	0x01,  				// bNumInterfaces
 	0x01,  				// bConfigurationValue
 	0x00,  				// iConfiguration


### PR DESCRIPTION
USB Get Descriptor Response for Configuration in DFU mode seems to
return one additional byte (0x44) from manufacturer string descriptor,
also it contain useless string descriptor.
Decrease wTotalLength to fix that.
