### PR TITLE
Fix indices in unrolled memcpy

### DIFF
--- a/firmware/bluetooth_rxtx/bluetooth_rxtx.c
+++ b/firmware/bluetooth_rxtx/bluetooth_rxtx.c
@@ -262,7 +262,7 @@ static int enqueue(u8 *buf)
 	/* Avoid gcc warning about strict-aliasing */
 	u16 *p3 = (u16 *)f->data;
 	u16 *p4 = (u16 *)buf;
-	p3[48] = p4[48];
+	p3[24] = p4[24];
 
 	f->status = status;
 	status = 0;


### PR DESCRIPTION
While investigating possible causes for issue #15 I noticed that there was an error copying the last two bytes of each packet. This seems to be a buffer overrun introduced in commit dd4073bfa1c069c298cd66028c16eaff17ce9014 "Avoid strict aliasing warning from gcc arm 4.7 - it's a silly warning."
I was hoping this might fix the issue... but it does not.
