### PR TITLE
Removes comment for find_package(PCAP)

### DIFF
--- a/host/libubertooth/src/CMakeLists.txt
+++ b/host/libubertooth/src/CMakeLists.txt
@@ -55,7 +55,7 @@ include_directories(${LIBUSB_INCLUDE_DIR} ${LIBBTBB_INCLUDE_DIR})
 LIST(APPEND LIBUBERTOOTH_LIBS ${LIBUSB_LIBRARIES} ${LIBBTBB_LIBRARIES})
 
 # Conditional libpcap support
-#find_package(PCAP)
+find_package(PCAP)
 if( ${PCAP_FOUND} )
 	include_directories(${PCAP_INCLUDE_DIRS})
 	LIST(APPEND LIBUBERTOOTH_LIBS ${PCAP_LIBRARIES})


### PR DESCRIPTION
Ubertooth would not build without this enabled on debian 7.7:

CMakeFiles/ubertooth-btle.dir/ubertooth-btle.c.o: In function `main':
ubertooth-btle.c:(.text+0x439): undefined reference to`h_pcap_le'
ubertooth-btle.c:(.text+0x44a): undefined reference to `h_pcap_le'
ubertooth-btle.c:(.text+0x493): undefined reference to`h_pcap_le'
ubertooth-btle.c:(.text+0x4a4): undefined reference to `h_pcap_le'
collect2: error: ld returned 1 exit status
make[2]: **\* [ubertooth-tools/src/ubertooth-btle] Error 1
make[1]: **\* [ubertooth-tools/src/CMakeFiles/ubertooth-btle.dir/all] Error 2
make: **\* [all] Error 2
