### PR TITLE
Update firmware README file.

### DIFF
--- a/firmware/README
+++ b/firmware/README
@@ -4,7 +4,12 @@ The general purpose firmware including Bluetooth functions is bluetooth_rxtx.
 
 This firmware is intended to be compiled with a particular toolchain:
 
-	https://code.launchpad.net/gcc-arm-embedded
+	https://launchpad.net/gcc-arm-embedded
+
+If you are using a recent Ubuntu or Debian system, the toolchain can be installed
+from their apt repositorities as follows:
+
+    apt-get install gcc-arm-none-eabi
 
 The default hardware target is Ubertooth One.  If you are compiling for
 Ubertooth Zero, you must set the environment variable BOARD=UBERTOOTH_ZERO.


### PR DESCRIPTION
URL now points to root page of gcc-arm-embedded toolchain project.

Add note about using apt-get to install toolchain on Ubuntu or Debian
systems.