### PR TITLE
fix CLKN calculation in cb_br_rx()

### DIFF
--- a/firmware/bluetooth_rxtx/bluetooth_rxtx.c
+++ b/firmware/bluetooth_rxtx/bluetooth_rxtx.c
@@ -68,12 +68,12 @@ volatile u8 keepalive_trigger;              // set by timer 1/s
 volatile u32 cs_timestamp;                  // CLK100NS at time of cs_trigger
 u16 hop_direct_channel = 0;                 // for hopping directly to a channel
 int clock_trim = 0;                         // to counteract clock drift
-u32 idle_buf_clkn_high;
-u32 active_buf_clkn_high;
-u32 idle_buf_clk100ns;
-u32 active_buf_clk100ns;
-u16 idle_buf_channel = 0;
-u16 active_buf_channel = 0;
+volatile u32 idle_buf_clkn_high;
+volatile u32 active_buf_clkn_high;
+volatile u32 idle_buf_clk100ns;
+volatile u32 active_buf_clk100ns;
+volatile u16 idle_buf_channel = 0;
+volatile u16 active_buf_channel = 0;
 u8 slave_mac_address[6] = { 0, };
 
 /* DMA buffers */

--- a/host/libubertooth/src/ubertooth.c
+++ b/host/libubertooth/src/ubertooth.c
@@ -498,7 +498,7 @@ static void cb_br_rx(void* args, usb_pkt_rx *rx, int bank)
 	/* Once offset is known for a valid packet, copy in symbols
 	 * and other rx data. CLKN here is the 312.5us CLK27-0. The
 	 * btbb library can shift it be CLK1 if needed. */
-	clkn = (rx->clkn_high << 20) + (le32toh(rx->clk100ns) + offset + 1562) / 3125;
+	clkn = (rx->clkn_high << 20) + (le32toh(rx->clk100ns) + offset*10) / 3125;
 	btbb_packet_set_data(pkt, syms + offset, NUM_BANKS * BANK_LEN - offset,
 			   rx->channel, clkn);
 


### PR DESCRIPTION
* make clk100ns values in the firmware volatile since they are modified inside an ISR
* change the offset in the clkn calculation in cb_br_rx(). At 1 Mbps,
  each bit has a duration of 1 us or 10 units of 100 ns. The bit offset
  is multiplied by this duration to calculate the correct clock offset.

this is related to:
  greatscottgadgets/ubertooth#84