### PR TITLE
OS/X getopt can not cope with optional arguments

### DIFF
--- a/host/ubertooth-tools/CMakeLists.txt
+++ b/host/ubertooth-tools/CMakeLists.txt
@@ -24,6 +24,10 @@
 project(ubertooth-tools C)
 set(PACKAGE ubertooth-tools)
 
+if(MSVC OR APPLE)
+    set(USE_OWN_GNU_GETOPT 1)
+endif()
+
 add_subdirectory(src)
 
 # Create uninstall target

--- a/host/ubertooth-tools/src/CMakeLists.txt
+++ b/host/ubertooth-tools/src/CMakeLists.txt
@@ -37,10 +37,10 @@ if( (NOT DEFINED USE_PCAP) OR USE_PCAP )
 	endif()
 endif()
 
-if(MSVC)
+if(USE_OWN_GNU_GETOPT)
 	include_directories(../getopt)
 	add_library(libgetopt_static STATIC ../getopt/getopt.c)
-endif(MSVC)
+endif(USE_OWN_GNU_GETOPT)
 
 if(NOT libubertooth_SOURCE_DIR)
 	find_package(UBERTOOTH REQUIRED)
@@ -55,9 +55,9 @@ include_directories(${LIBUSB_INCLUDE_DIR} ${LIBBTBB_INCLUDE_DIR})
 
 LIST(APPEND TOOLS_LINK_LIBS ${LIBUSB_LIBRARIES} ${LIBBTBB_LIBRARIES})
 
-if(MSVC)
+if(USE_OWN_GNU_GETOPT)
 	LIST(APPEND TOOLS_LINK_LIBS libgetopt_static)
-endif()
+endif(USE_OWN_GNU_GETOPT)
 
 LIST(APPEND TOOLS ubertooth-rx ubertooth-dump ubertooth-util ubertooth-btle ubertooth-dfu ubertooth-specan)
 


### PR DESCRIPTION
Hi,
the getopt() implementation on OS/X can not handle optional command line arguments. Thus a call to `ubertooth-util -c` will not return the configured channel, but an error message, complaining about the missing argument. A workaround seems to be to use `-cc` instead.

As ubertooth ships already with a working getopt version that is used under windows, I would like to use the same version under OS/X.

Cheers,
Torsten