### PR TITLE
store ubertooth status inside a struct instead of globals

### DIFF
--- a/host/libubertooth/src/ubertooth.c
+++ b/host/libubertooth/src/ubertooth.c
@@ -596,7 +596,7 @@ void rx_file(FILE* fp, btbb_piconet* pn)
 /*
  * Sniff Bluetooth Low Energy packets.
  */
-void cb_btle(ubertooth_t* ut, void* args, usb_pkt_rx *rx, int bank)
+void cb_btle(ubertooth_t* ut, void* args, usb_pkt_rx *rx, int bank __attribute__((unused)))
 {
 	lell_packet * pkt;
 	btle_options * opts = (btle_options *) args;
@@ -606,8 +606,6 @@ void cb_btle(ubertooth_t* ut, void* args, usb_pkt_rx *rx, int bank)
 	static u32 prev_ts = 0;
 	uint32_t refAA;
 	int8_t sig, noise;
-
-	UNUSED(bank);
 
 	// display LE promiscuous mode state changes
 	if (rx->pkt_type == LE_PROMISC) {
@@ -715,12 +713,10 @@ void cb_btle(ubertooth_t* ut, void* args, usb_pkt_rx *rx, int bank)
 /*
  * Sniff E-GO packets
  */
-void cb_ego(ubertooth_t* ut, void* args __attribute__((unused)), usb_pkt_rx *rx, int bank)
+void cb_ego(ubertooth_t* ut __attribute__((unused)), void* args __attribute__((unused)), usb_pkt_rx *rx, int bank __attribute__((unused)))
 {
 	int i;
 	static u32 prev_ts = 0;
-
-	UNUSED(bank);
 
 	u32 rx_time = rx->clk100ns;
 	if (rx_time < prev_ts)
@@ -745,12 +741,10 @@ void rx_btle_file(FILE* fp)
 	stream_rx_file(fp, cb_btle, NULL);
 }
 
-static void cb_dump_bitstream(ubertooth_t* ut, void* args, usb_pkt_rx *rx, int bank)
+static void cb_dump_bitstream(ubertooth_t* ut, void* args __attribute__((unused)), usb_pkt_rx *rx, int bank)
 {
 	int i;
 	char nl = '\n';
-
-	UNUSED(args);
 
 	unpack_symbols(rx->data, ut->br_symbols[bank]);
 
@@ -768,12 +762,9 @@ static void cb_dump_bitstream(ubertooth_t* ut, void* args, usb_pkt_rx *rx, int b
 	}
 }
 
-static void cb_dump_full(ubertooth_t* ut, void* args, usb_pkt_rx *rx, int bank)
+static void cb_dump_full(ubertooth_t* ut __attribute__((unused)), void* args __attribute__((unused)), usb_pkt_rx *rx, int bank __attribute__((unused)))
 {
 	uint8_t *buf = (uint8_t*)rx;
-
-	UNUSED(args);
-	UNUSED(bank);
 
 	fprintf(stderr, "rx block timestamp %u * 100 nanoseconds\n", rx->clk100ns);
 	uint32_t time_be = htobe32((uint32_t)time(NULL));
@@ -930,7 +921,7 @@ ubertooth_t* ubertooth_init()
 	ut->usb_really_full = 0;
 	ut->usb_retry = 1;
 	ut->stop_ubertooth = 0;
-	ut->abs_start_ns;
+	ut->abs_start_ns = 0;
 	ut->start_clk100ns = 0;
 	ut->last_clk100ns = 0;
 	ut->clk100ns_upper = 0;

--- a/host/libubertooth/src/ubertooth.h
+++ b/host/libubertooth/src/ubertooth.h
@@ -25,9 +25,6 @@
 #include "ubertooth_control.h"
 #include <btbb.h>
 
-/* Mark unused variables to avoid gcc/clang warnings */
-#define UNUSED(x) (void)(x)
-
 /* specan output types
  * see https://github.com/dkogan/feedgnuplot for plotter */
 enum specan_modes {

--- a/host/libubertooth/src/ubertooth.h
+++ b/host/libubertooth/src/ubertooth.h
@@ -43,29 +43,49 @@ enum board_ids {
 	BOARD_ID_TC13BADGE      = 2
 };
 
-typedef void (*rx_callback)(void* args, usb_pkt_rx *rx, int bank);
+typedef struct {
+	usb_pkt_rx usb_packets[NUM_BANKS];
+	char br_symbols[NUM_BANKS][BANK_LEN];
+
+	struct libusb_device_handle* devh;
+	struct libusb_transfer* rx_xfer;
+	uint8_t* empty_usb_buf;
+	uint8_t* full_usb_buf;
+	uint8_t usb_really_full;
+	uint8_t usb_retry;
+
+	uint8_t stop_ubertooth;
+	uint64_t abs_start_ns;
+	uint32_t start_clk100ns;
+	uint64_t last_clk100ns;
+	uint64_t clk100ns_upper;
+	btbb_piconet* follow_pn;
+} ubertooth_t;
+
+typedef void (*rx_callback)(ubertooth_t* ut, void* args, usb_pkt_rx *rx, int bank);
 
 typedef struct {
 	unsigned allowed_access_address_errors;
 } btle_options;
 
 void print_version();
-void register_cleanup_handler(struct libusb_device_handle *devh);
-struct libusb_device_handle* ubertooth_start(int ubertooth_device);
-void ubertooth_stop(struct libusb_device_handle *devh);
-int specan(struct libusb_device_handle* devh, int xfer_size, u16 low_freq,
+void register_cleanup_handler(ubertooth_t* ut);
+ubertooth_t* ubertooth_init();
+ubertooth_t* ubertooth_start(int ubertooth_device);
+void ubertooth_stop(ubertooth_t* ut);
+int specan(ubertooth_t* ut, int xfer_size, u16 low_freq,
 		   u16 high_freq, u8 output_mode);
 int cmd_ping(struct libusb_device_handle* devh);
-int stream_rx_usb(struct libusb_device_handle* devh, int xfer_size,
+int stream_rx_usb(ubertooth_t* ut, int xfer_size,
 				  rx_callback cb, void* cb_args);
 int stream_rx_file(FILE* fp, rx_callback cb, void* cb_args);
-void rx_live(struct libusb_device_handle* devh, btbb_piconet* pn, int timeout);
+void rx_live(ubertooth_t* ut, btbb_piconet* pn, int timeout);
 void rx_file(FILE* fp, btbb_piconet* pn);
-void rx_dump(struct libusb_device_handle* devh, int full);
-void rx_btle(struct libusb_device_handle* devh);
+void rx_dump(ubertooth_t* ut, int full);
+void rx_btle(ubertooth_t* ut);
 void rx_btle_file(FILE* fp);
-void cb_btle(void* args, usb_pkt_rx *rx, int bank);
-void cb_ego(void* args, usb_pkt_rx *rx, int bank);
+void cb_btle(ubertooth_t* ut, void* args, usb_pkt_rx *rx, int bank);
+void cb_ego(ubertooth_t* ut, void* args, usb_pkt_rx *rx, int bank);
 
 #ifdef ENABLE_PCAP
 extern btbb_pcap_handle * h_pcap_bredr;

--- a/host/ubertooth-tools/src/ubertooth-debug.c
+++ b/host/ubertooth-tools/src/ubertooth-debug.c
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
     int opt;
     int r = 0;
     int verbose = 1;
-    struct libusb_device_handle *devh = NULL;
+    ubertooth_t* ut = NULL;
     int do_read_register;
     char ubertooth_device = -1;
     int *regList = NULL;
@@ -117,15 +117,15 @@ int main(int argc, char *argv[])
     }
 
     /* initialise device */
-    devh = ubertooth_start(ubertooth_device);
-    if (devh == NULL) {
+    ut = ubertooth_start(ubertooth_device);
+    if (ut == NULL) {
 	usage();
 	return 1;
     }
 
     if (do_read_register >= 0) {
 	for (i = 0; i < regListN; i++) {
-	    r = cmd_read_register(devh, regList[i]);
+	    r = cmd_read_register(ut->devh, regList[i]);
 	    if (r >= 0)
 		cc2400_decode(stdout, regList[i], r, verbose);
 	}

--- a/host/ubertooth-tools/src/ubertooth-dfu.c
+++ b/host/ubertooth-tools/src/ubertooth-dfu.c
@@ -406,6 +406,7 @@ int main(int argc, char **argv) {
 	uint8_t functions = 0;
 	int opt, ubertooth_device = -1;
 	int r;
+	ubertooth_t* ut = NULL;
 	
 	while ((opt=getopt(argc,argv,"hd:u:s:rU:")) != EOF) {
 		switch(opt) {
@@ -468,7 +469,8 @@ int main(int argc, char **argv) {
 		int rv, count= 0;
 		devh = find_ubertooth_dfu_device();
 		if(devh == NULL) {
-			devh = ubertooth_start(ubertooth_device);
+			ut = ubertooth_start(ubertooth_device);
+			devh = ut->devh;
 			cmd_flash(devh);
 			fprintf(stdout, "Switching to DFU mode...\n");
 			while(((devh = find_ubertooth_dfu_device()) == NULL) && (count++) < 5)

--- a/host/ubertooth-tools/src/ubertooth-dump.c
+++ b/host/ubertooth-tools/src/ubertooth-dump.c
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
 	int bitstream = 0;
 	int modulation = MOD_BT_BASIC_RATE;
 	char ubertooth_device = -1;
-	struct libusb_device_handle *devh = NULL;
+	ubertooth_t* ut = NULL;
 
 	while ((opt=getopt(argc,argv,"bhclU:d:")) != EOF) {
 		switch(opt) {
@@ -83,19 +83,19 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	devh = ubertooth_start(ubertooth_device);
+	ut = ubertooth_start(ubertooth_device);
 
-	if (devh == NULL) {
+	if (ut == NULL) {
 		usage();
 		return 1;
 	}
 
 	/* Clean up on exit. */
-	register_cleanup_handler(devh);
+	register_cleanup_handler(ut);
 
-	cmd_set_modulation(devh, modulation);
-	rx_dump(devh, bitstream);
+	cmd_set_modulation(ut->devh, modulation);
+	rx_dump(ut, bitstream);
 
-	ubertooth_stop(devh);
+	ubertooth_stop(ut);
 	return 0;
 }

--- a/host/ubertooth-tools/src/ubertooth-ego.c
+++ b/host/ubertooth-tools/src/ubertooth-ego.c
@@ -27,7 +27,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 
-struct libusb_device_handle *devh = NULL;
+ubertooth_t* ut = NULL;
 
 static void usage(void)
 {
@@ -77,22 +77,22 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	devh = ubertooth_start(ubertooth_device);
-	if (devh == NULL) {
+	ut = ubertooth_start(ubertooth_device);
+	if (ut == NULL) {
 		usage();
 		return 1;
 	}
 
 	/* Clean up on exit. */
-	register_cleanup_handler(devh);
+	register_cleanup_handler(ut);
 
 	if (do_mode >= 0) {
 		usb_pkt_rx pkt;
 
 		if (do_mode == 1) // FIXME magic number!
-			cmd_set_channel(devh, do_channel);
+			cmd_set_channel(ut->devh, do_channel);
 
-		r = cmd_ego(devh, do_mode);
+		r = cmd_ego(ut->devh, do_mode);
 		if (r < 0) {
 			if (do_mode == 0 || do_mode == 1)
 				printf("Error: E-GO not supported by this firmware\n");
@@ -102,16 +102,16 @@ int main(int argc, char *argv[])
 		}
 
 		while (1) {
-			int r = cmd_poll(devh, &pkt);
+			int r = cmd_poll(ut->devh, &pkt);
 			if (r < 0) {
 				printf("USB error\n");
 				break;
 			}
 			if (r == sizeof(usb_pkt_rx))
-				cb_ego(NULL, &pkt, 0);
+				cb_ego(ut, NULL, &pkt, 0);
 			usleep(500);
 		}
-		ubertooth_stop(devh);
+		ubertooth_stop(ut);
 	}
 
 	return 0;

--- a/host/ubertooth-tools/src/ubertooth-follow.c
+++ b/host/ubertooth-tools/src/ubertooth-follow.c
@@ -33,10 +33,9 @@
 #include <getopt.h>
 
 extern int max_ac_errors;
-extern btbb_piconet *follow_pn;
 extern FILE *dumpfile;
 
-struct libusb_device_handle *devh = NULL;
+ubertooth_t* ut = NULL;
 
 static void usage()
 {
@@ -224,22 +223,22 @@ int main(int argc, char *argv[])
 	}
 	
 	/* Clean up on exit. */
-	register_cleanup_handler(devh);
+	register_cleanup_handler(ut);
 	
-	devh = ubertooth_start(ubertooth_device);
-	if (devh == NULL) {
+	ut = ubertooth_start(ubertooth_device);
+	if (ut == NULL) {
 		usage();
 		return 1;
 	}
-	cmd_set_bdaddr(devh, btbb_piconet_get_bdaddr(pn));
+	cmd_set_bdaddr(ut->devh, btbb_piconet_get_bdaddr(pn));
 	if(afh_enabled)
-		cmd_set_afh_map(devh, afh_map);
+		cmd_set_afh_map(ut->devh, afh_map);
 	btbb_piconet_set_clk_offset(pn, clock+delay);
 	btbb_piconet_set_flag(pn, BTBB_FOLLOWING, 1);
 	btbb_piconet_set_flag(pn, BTBB_CLK27_VALID, 1);
-	follow_pn = pn;
-	rx_live(devh, pn, 0);
-	ubertooth_stop(devh);
+	ut->follow_pn = pn;
+	rx_live(ut, pn, 0);
+	ubertooth_stop(ut);
 
 	return 0;
 }

--- a/host/ubertooth-tools/src/ubertooth-rx.c
+++ b/host/ubertooth-tools/src/ubertooth-rx.c
@@ -28,7 +28,7 @@ extern FILE *dumpfile;
 extern FILE *infile;
 extern int max_ac_errors;
 
-struct libusb_device_handle *devh = NULL;
+ubertooth_t* ut = NULL;
 
 static void usage()
 {
@@ -148,8 +148,8 @@ int main(int argc, char *argv[])
 	}
 
 	if (infile == NULL) {
-		devh = ubertooth_start(ubertooth_device);
-		if (devh == NULL) {
+		ut = ubertooth_start(ubertooth_device);
+		if (ut == NULL) {
 			usage();
 			return 1;
 		}
@@ -158,19 +158,19 @@ int main(int argc, char *argv[])
 		 * ubertooth-utils -c9999. This is necessary after
 		 * following a piconet. */
 		if (reset_scan) {
-			cmd_set_channel(devh, 9999);
+			cmd_set_channel(ut->devh, 9999);
 		}
 
 		/* Clean up on exit. */
-		register_cleanup_handler(devh);
+		register_cleanup_handler(ut);
 
-		rx_live(devh, pn, timeout);
+		rx_live(ut, pn, timeout);
 
 		// Print AFH map from piconet if we have one
 		if (pn)
 			btbb_print_afh_map(pn);
 
-		ubertooth_stop(devh);
+		ubertooth_stop(ut);
 	} else {
 		rx_file(infile, pn);
 		fclose(infile);

--- a/host/ubertooth-tools/src/ubertooth-scan.c
+++ b/host/ubertooth-tools/src/ubertooth-scan.c
@@ -188,7 +188,7 @@ int main(int argc, char *argv[])
 	char ubertooth_device = -1;
 	char *bt_dev = "hci0";
     char addr[19] = { 0 };
-	struct libusb_device_handle *devh = NULL;
+	ubertooth_t* ut = NULL;
 	btbb_piconet *pn;
 	bdaddr_t bdaddr;
 
@@ -235,13 +235,13 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
-	devh = ubertooth_start(ubertooth_device);
-	if (devh == NULL) {
+	ut = ubertooth_start(ubertooth_device);
+	if (ut == NULL) {
 		usage();
 		return 1;
 	}
 	/* Set sweep mode - otherwise AFH map is useless */
-	cmd_set_channel(devh, 9999);
+	cmd_set_channel(ut->devh, 9999);
 
 	if (scan) {
 		/* Equivalent to "hcitool scan" */
@@ -266,8 +266,8 @@ int main(int argc, char *argv[])
 	/* Now find hidden piconets with Ubertooth */
 	printf("\nUbertooth scan\n");
 	btbb_init_survey();
-	rx_live(devh, NULL, timeout);
-	ubertooth_stop(devh);
+	rx_live(ut, NULL, timeout);
+	ubertooth_stop(ut);
 
 	while((pn=btbb_next_survey_result()) != NULL) {
 		lap = btbb_piconet_get_lap(pn);

--- a/host/ubertooth-tools/src/ubertooth-specan.c
+++ b/host/ubertooth-tools/src/ubertooth-specan.c
@@ -26,7 +26,7 @@
 extern u8 debug;
 extern FILE *dumpfile;
 
-struct libusb_device_handle *devh = NULL;
+ubertooth_t* ut = NULL;
 
 static void usage(FILE *file)
 {
@@ -95,23 +95,23 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	devh = ubertooth_start(ubertooth_device);
+	ut = ubertooth_start(ubertooth_device);
 
-	if (devh == NULL) {
+	if (ut == NULL) {
 		usage(stderr);
 		return 1;
 	}
 	
 	/* Clean up on exit. */
-	register_cleanup_handler(devh);
+	register_cleanup_handler(ut);
 	
 	while (1) {
-		r = specan(devh, 512, lower, upper, output_mode);
+		r = specan(ut, 512, lower, upper, output_mode);
 		if(r<0)
 			break;
 	}
 
-	ubertooth_stop(devh);
+	ubertooth_stop(ut);
 	fprintf(stderr, "Ubertooth stopped\n");
 	return r;
 }

--- a/host/ubertooth-tools/src/ubertooth-util.c
+++ b/host/ubertooth-tools/src/ubertooth-util.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
 {
 	int opt;
 	int r = 0;
-	struct libusb_device_handle *devh= NULL;
+	ubertooth_t* ut = NULL;
 	rangetest_result rr;
 	int do_stop, do_flash, do_isp, do_leds, do_part, do_reset;
 	int do_serial, do_tx, do_palevel, do_channel, do_led_specan;
@@ -188,71 +188,71 @@ int main(int argc, char *argv[])
 	}
 
 	/* initialise device */
-	devh = ubertooth_start(ubertooth_device);
-	if (devh == NULL) {
+	ut = ubertooth_start(ubertooth_device);
+	if (ut == NULL) {
 		usage();
 		return 1;
 	}
 	if(do_reset == 0) {
 		printf("Resetting ubertooth device number %d\n", (ubertooth_device >= 0) ? ubertooth_device : 0);
-		r = cmd_reset(devh);
+		r = cmd_reset(ut->devh);
 		sleep(2);
-		devh = ubertooth_start(ubertooth_device);
+		ut = ubertooth_start(ubertooth_device);
 	}
 	if(do_stop == 0) {
 		printf("Stopping ubertooth device number %d\n", (ubertooth_device >= 0) ? ubertooth_device : 0);
-		r= cmd_stop(devh);
+		r = cmd_stop(ut->devh);
 	}
 
 	/* device configuration actions */
 	if(do_all_leds == 0 || do_all_leds == 1) {
-		cmd_set_usrled(devh, do_all_leds);
-		cmd_set_rxled(devh, do_all_leds);
-		r= cmd_set_txled(devh, do_all_leds);
+		cmd_set_usrled(ut->devh, do_all_leds);
+		cmd_set_rxled(ut->devh, do_all_leds);
+		r= cmd_set_txled(ut->devh, do_all_leds);
 		r = (r >= 0) ? 0 : r;
 	}
 	if(do_channel > 0)
-		r= cmd_set_channel(devh, do_channel);
+		r= cmd_set_channel(ut->devh, do_channel);
 	if(do_leds == 0 || do_leds == 1)
-		r= cmd_set_usrled(devh, do_leds);
+		r= cmd_set_usrled(ut->devh, do_leds);
 	if(do_palevel > 0)
-		r= cmd_set_palevel(devh, do_palevel);
+		r= cmd_set_palevel(ut->devh, do_palevel);
 	
 	/* reporting actions */
 	if(do_all_leds == 2) {
-		printf("USR LED status: %d\n", cmd_get_usrled(devh));
-		printf("RX LED status : %d\n", cmd_get_rxled(devh));
-		printf("TX LED status : %d\n", r= cmd_get_txled(devh));
+		printf("USR LED status: %d\n", cmd_get_usrled(ut->devh));
+		printf("RX LED status : %d\n", cmd_get_rxled(ut->devh));
+		printf("TX LED status : %d\n", r= cmd_get_txled(ut->devh));
 		r = (r >= 0) ? 0 : r;
 	}
 	if(do_board_id == 0) {
-		r= cmd_get_board_id(devh);
+		r= cmd_get_board_id(ut->devh);
 		printf("Board ID Number: %d (%s)\n", r, board_names[r]);
 	}
 	if(do_channel == 0) {
-		r= cmd_get_channel(devh);
+		r= cmd_get_channel(ut->devh);
 		printf("Current frequency: %d MHz (Bluetooth channel %d)\n", r, r - 2402);
 		}
 	if(do_firmware == 0) {
 		char version[255];
-		cmd_get_rev_num(devh, version, (u8)sizeof(version));
+		cmd_get_rev_num(ut->devh, version, (u8)sizeof(version));
 		printf("Firmware revision: %s\n", version);
         }
 	if(do_compile_info == 0) {
 		char compile_info[255];
-		cmd_get_compile_info(devh, compile_info, (u8)sizeof(compile_info));
+		cmd_get_compile_info(ut->devh, compile_info, (u8)sizeof(compile_info));
 		puts(compile_info);
 	}
 	if(do_leds == 2)
-		printf("USR LED status: %d\n", r= cmd_get_usrled(devh));
+		printf("USR LED status: %d\n", r= cmd_get_usrled(ut->devh));
 	if(do_palevel == 0)
-		printf("PA Level: %d\n", r= cmd_get_palevel(devh));
+		printf("PA Level: %d\n", r= cmd_get_palevel(ut->devh));
 	if(do_part == 0) {
-		printf("Part ID: %X\n", r = cmd_get_partnum(devh));
+		printf("Part ID: %X\n", r = cmd_get_partnum(ut->devh));
 		r = (r >= 0) ? 0 : r;
 	}
 	if(do_range_result == 0) {
-		r = cmd_get_rangeresult(devh, &rr);
+		r = cmd_get_rangeresult(ut->devh, &rr);
 		if (r == 0) {
 			if (rr.valid==1) {
 				printf("request PA level : %d\n", rr.request_pa);
@@ -268,7 +268,7 @@ int main(int argc, char *argv[])
 	}
 	if(do_serial == 0) {
 		u8 serial[17];
-		r= cmd_get_serial(devh, serial);
+		r= cmd_get_serial(ut->devh, serial);
 		if(r==0) {
 			print_serial(serial, NULL);
 		}
@@ -279,51 +279,51 @@ int main(int argc, char *argv[])
 	/* final actions */
 	if(do_flash == 0) {
 		printf("Entering flash programming (DFU) mode\n");
-		return cmd_flash(devh);
+		return cmd_flash(ut->devh);
 	}
 	if(do_identify == 0) {
 		printf("Flashing LEDs on ubertooth device number %d\n", (ubertooth_device >= 0) ? ubertooth_device : 0);
 		while(42) {
 			do_identify= !do_identify;
-			cmd_set_usrled(devh, do_identify);
-			cmd_set_rxled(devh, do_identify);
-			cmd_set_txled(devh, do_identify);
+			cmd_set_usrled(ut->devh, do_identify);
+			cmd_set_rxled(ut->devh, do_identify);
+			cmd_set_txled(ut->devh, do_identify);
 			sleep(1);
 		}
 	}
 	if(do_isp == 0) {
 		printf("Entering flash programming (ISP) mode\n");
-		return cmd_set_isp(devh);
+		return cmd_set_isp(ut->devh);
 	}
 	if(do_led_specan >= 0) {
 		do_led_specan= do_led_specan ? do_led_specan : 225;
 		printf("Entering LED specan mode (RSSI %d)\n", do_led_specan);
-		return cmd_led_specan(devh, do_led_specan);
+		return cmd_led_specan(ut->devh, do_led_specan);
 	}
 	if(do_range_test == 0) {
 		printf("Starting range test\n");
-		return cmd_range_test(devh);
+		return cmd_range_test(ut->devh);
 	}
 	if(do_repeater == 0) {
 		printf("Starting repeater\n");
-		return cmd_repeater(devh);
+		return cmd_repeater(ut->devh);
 	}
 	if(do_tx == 0) {
 		printf("Starting TX test\n");
-		return cmd_tx_test(devh);
+		return cmd_tx_test(ut->devh);
 	}
 	if(do_set_squelch > 0) {
 		printf("Setting squelch to %d\n", squelch_level);
-		cmd_set_squelch(devh, squelch_level);
+		cmd_set_squelch(ut->devh, squelch_level);
 	}
 	if(do_get_squelch > 0) {
-		r = cmd_get_squelch(devh);
+		r = cmd_get_squelch(ut->devh);
 		printf("Squelch set to %d\n", (int8_t)r);
 	}
 	if(do_something) {
 		unsigned char buf[4] = { 0x55, 0x55, 0x55, 0x55 };
-		cmd_do_something(devh, NULL, 0);
-		cmd_do_something_reply(devh, buf, 4);
+		cmd_do_something(ut->devh, NULL, 0);
+		cmd_do_something_reply(ut->devh, buf, 4);
 		printf("%02x %02x %02x %02x\n", buf[0], buf[1], buf[2], buf[3]);
 		return 0;
 	}


### PR DESCRIPTION
This is my first step for modularizing libubertooth. This is especially important for my attempts to support AFH which was the topic of my diploma thesis.

The state of an ubertooth device is stored inside of a struct type ubertooth_t, which is defined in ubertooth.h of libubertooth. Host tools and functions in libubertooth use this type when forwarding the ubertooth state to other functions.

This commit has a lot of changes in code but only few changes in functionality. I successfully tested ubertooth-dfu, ubertooth-rx, ubertooth-dump, ubertooth-specan and ubertooth-scan with my changes.

Feedback and suggestions are always welcome. Thanks!

Hannes