### PR TITLE
ringbuffer datastructure for libubertooth

### DIFF
--- a/host/libubertooth/src/CMakeLists.txt
+++ b/host/libubertooth/src/CMakeLists.txt
@@ -38,9 +38,11 @@ add_definitions( -DRELEASE="${RELEASE}${DIRTY_FLAG}" )
 # Targets
 set(c_sources ${CMAKE_CURRENT_SOURCE_DIR}/ubertooth.c
               ${CMAKE_CURRENT_SOURCE_DIR}/ubertooth_control.c
+              ${CMAKE_CURRENT_SOURCE_DIR}/ubertooth_ringbuffer.c
 			  CACHE INTERNAL "List of C sources")
 set(c_headers ${CMAKE_CURRENT_SOURCE_DIR}/ubertooth.h
               ${CMAKE_CURRENT_SOURCE_DIR}/ubertooth_control.h
+              ${CMAKE_CURRENT_SOURCE_DIR}/ubertooth_ringbuffer.h
 			  ${CMAKE_CURRENT_SOURCE_DIR}/ubertooth_interface.h
 			  CACHE INTERNAL "List of C headers")
 

--- a/host/libubertooth/src/ubertooth.c
+++ b/host/libubertooth/src/ubertooth.c
@@ -51,7 +51,7 @@ lell_pcapng_handle * h_pcapng_le = NULL;
 
 void print_version() {
 	printf("libubertooth %s (%s), libbtbb %s (%s)\n", VERSION, RELEASE,
-		   btbb_get_version(), btbb_get_release());
+	       btbb_get_version(), btbb_get_release());
 }
 
 ubertooth_t* cleanup_devh = NULL;
@@ -81,8 +81,8 @@ void stop_transfers(int sig __attribute__((unused))) {
 void set_timeout(ubertooth_t* ut, int seconds) {
 	/* Upon SIGALRM, call stop_transfers() */
 	if (signal(SIGALRM, stop_transfers) == SIG_ERR) {
-	  perror("Unable to catch SIGALRM");
-	  exit(1);
+		perror("Unable to catch SIGALRM");
+		exit(1);
 	}
 	timeout_dev = ut;
 	alarm(seconds);
@@ -103,14 +103,14 @@ static struct libusb_device_handle* find_ubertooth_device(int ubertooth_device)
 		if(r < 0)
 			fprintf(stderr, "couldn't get usb descriptor for dev #%d!\n", i);
 		if ((desc.idVendor == TC13_VENDORID && desc.idProduct == TC13_PRODUCTID)
-			|| (desc.idVendor == U0_VENDORID && desc.idProduct == U0_PRODUCTID)
-			|| (desc.idVendor == U1_VENDORID && desc.idProduct == U1_PRODUCTID))
+		    || (desc.idVendor == U0_VENDORID && desc.idProduct == U0_PRODUCTID)
+		    || (desc.idVendor == U1_VENDORID && desc.idProduct == U1_PRODUCTID))
 		{
 			ubertooth_devs[ubertooths] = i;
 			ubertooths++;
 		}
 	}
-	if(ubertooths == 1) { 
+	if(ubertooths == 1) {
 		ret = libusb_open(usb_list[ubertooth_devs[0]], &devh);
 		if (ret)
 			show_libusb_error(ret);
@@ -207,7 +207,7 @@ static void cb_xfer(struct libusb_transfer *xfer)
 		fprintf(stderr, "uh oh, full_usb_buf not emptied\n");
 		ut->stop_ubertooth = 1;
 	}
-	
+
 	if(ut->stop_ubertooth)
 		return;
 
@@ -222,8 +222,7 @@ static void cb_xfer(struct libusb_transfer *xfer)
 		fprintf(stderr, "Failed to submit USB transfer (%d)\n", r);
 }
 
-int stream_rx_usb(ubertooth_t* ut, int xfer_size,
-		rx_callback cb, void* cb_args)
+int stream_rx_usb(ubertooth_t* ut, int xfer_size, rx_callback cb, void* cb_args)
 {
 	int xfer_blocks, i, r;
 	usb_pkt_rx* rx;
@@ -247,7 +246,7 @@ int stream_rx_usb(ubertooth_t* ut, int xfer_size,
 	ut->usb_really_full = 0;
 	ut->rx_xfer = libusb_alloc_transfer(0);
 	libusb_fill_bulk_transfer(ut->rx_xfer, ut->devh, DATA_IN, ut->empty_usb_buf,
-			xfer_size, cb_xfer, ut, TIMEOUT);
+	                          xfer_size, cb_xfer, ut, TIMEOUT);
 
 	cmd_rx_syms(ut->devh);
 
@@ -270,7 +269,7 @@ int stream_rx_usb(ubertooth_t* ut, int xfer_size,
 		/* process each received block */
 		for (i = 0; i < xfer_blocks; i++) {
 			rx = (usb_pkt_rx *)(ut->full_usb_buf + PKT_LEN * i);
-			if(rx->pkt_type != KEEP_ALIVE) 
+			if(rx->pkt_type != KEEP_ALIVE)
 				(*cb)(ut, cb_args, rx, bank);
 			bank = (bank + 1) % NUM_BANKS;
 			if(ut->stop_ubertooth) {
@@ -323,7 +322,7 @@ static void unpack_symbols(uint8_t* buf, char* unpacked)
 	}
 }
 
-static int8_t cc2400_rssi_to_dbm( const int8_t rssi ) 
+static int8_t cc2400_rssi_to_dbm( const int8_t rssi )
 {
 	/* models the cc2400 datasheet fig 22 for 1M as piece-wise linear */
 	if (rssi < -48) {
@@ -351,20 +350,20 @@ static int8_t cc2400_rssi_to_dbm( const int8_t rssi )
 
 static int8_t rssi_history[NUM_BREDR_CHANNELS][RSSI_HISTORY_LEN] = {{INT8_MIN}};
 
-static void determine_signal_and_noise( usb_pkt_rx *rx, int8_t * sig, int8_t * noise ) 
+static void determine_signal_and_noise( usb_pkt_rx *rx, int8_t * sig, int8_t * noise )
 {
 	int8_t * channel_rssi_history = rssi_history[rx->channel];
 	int8_t rssi;
 	int i;
 
-        /* Shift rssi max history and append current max */
+	/* Shift rssi max history and append current max */
 	memmove(channel_rssi_history,
-		channel_rssi_history+1,
-		RSSI_HISTORY_LEN-1);
+	        channel_rssi_history+1,
+	        RSSI_HISTORY_LEN-1);
 	channel_rssi_history[RSSI_HISTORY_LEN-1] = rx->rssi_max;
 
 #if 0
-        /* Signal starts in oldest bank, but may cross into second
+	/* Signal starts in oldest bank, but may cross into second
 	 * oldest bank.  Take the max or the 2 maxs. */
 	rssi = MAX(channel_rssi_history[0], channel_rssi_history[1]);
 #else
@@ -414,9 +413,9 @@ static void track_clk100ns( ubertooth_t* ut, const usb_pkt_rx* rx )
 static uint64_t now_ns_from_clk100ns( ubertooth_t* ut, const usb_pkt_rx* rx )
 {
 	track_clk100ns( ut, rx );
-	return ut->abs_start_ns + 
-		100ull*(uint64_t)((rx->clk100ns-ut->start_clk100ns)&0xffffffff) +
-		((100ull*ut->clk100ns_upper)<<32);
+	return ut->abs_start_ns +
+	       100ull*(uint64_t)((rx->clk100ns-ut->start_clk100ns)&0xffffffff) +
+	       ((100ull*ut->clk100ns_upper)<<32);
 }
 
 /* Sniff for LAPs. If a piconet is provided, use the given LAP to
@@ -461,7 +460,7 @@ static void cb_br_rx(ubertooth_t* ut, void* args, usb_pkt_rx* rx, int bank)
 		memcpy(syms + i * BANK_LEN,
 		       ut->br_symbols[(i + 1 + bank) % NUM_BANKS],
 		       BANK_LEN);
-	
+
 	/* Look for packets with specified LAP, if given. Otherwise
 	 * search for any packet.  Also determine if UAP is known. */
 	if (pn) {
@@ -489,7 +488,7 @@ static void cb_br_rx(ubertooth_t* ut, void* args, usb_pkt_rx* rx, int bank)
 	 * btbb library can shift it be CLK1 if needed. */
 	clkn = (rx->clkn_high << 20) + (le32toh(rx->clk100ns) + offset*10) / 3125;
 	btbb_packet_set_data(pkt, syms + offset, NUM_BANKS * BANK_LEN - offset,
-			   rx->channel, clkn);
+	                     rx->channel, clkn);
 
 	/* When reading from file, caller will read
 	 * systime before calling this routine, so do
@@ -503,12 +502,12 @@ static void cb_br_rx(ubertooth_t* ut, void* args, usb_pkt_rx* rx, int bank)
 	if (dumpfile) {
 		for(i = 0; i < NUM_BANKS; i++) {
 			uint32_t systime_be = htobe32(systime);
-			if (fwrite(&systime_be, 
-				   sizeof(systime_be), 1,
-				   dumpfile)
+			if (fwrite(&systime_be,
+			    sizeof(systime_be), 1,
+			    dumpfile)
 			    != 1) {;}
 			if (fwrite(&(ut->usb_packets[(i + 1 + bank) % NUM_BANKS]),
-				   sizeof(usb_pkt_rx), 1, dumpfile)
+			    sizeof(usb_pkt_rx), 1, dumpfile)
 			    != 1) {;}
 		}
 		fflush(dumpfile);
@@ -531,16 +530,16 @@ static void cb_br_rx(ubertooth_t* ut, void* args, usb_pkt_rx* rx, int bank)
 #ifdef ENABLE_PCAP
 	if (h_pcap_bredr) {
 		btbb_pcap_append_packet(h_pcap_bredr, nowns,
-					signal_level, noise_level,
-					lap, uap, pkt);
+		                        signal_level, noise_level,
+		                        lap, uap, pkt);
 	}
 #endif
 	if (h_pcapng_bredr) {
-		btbb_pcapng_append_packet(h_pcapng_bredr, nowns, 
-					signal_level, noise_level,
-					lap, uap, pkt);
+		btbb_pcapng_append_packet(h_pcapng_bredr, nowns,
+		                          signal_level, noise_level,
+		                          lap, uap, pkt);
 	}
-	
+
 	if(i < 0) {
 		ut->follow_pn = pn;
 		ut->stop_ubertooth = 1;
@@ -665,7 +664,7 @@ void cb_btle(ubertooth_t* ut, void* args, usb_pkt_rx *rx, int bank __attribute__
 
 	/* Dump to PCAP/PCAPNG if specified */
 	refAA = lell_packet_is_data(pkt) ? 0 : 0x8e89bed6;
-	determine_signal_and_noise( rx, &sig, &noise );	
+	determine_signal_and_noise( rx, &sig, &noise );
 #ifdef ENABLE_PCAP
 	if (h_pcap_le) {
 		/* only one of these two will succeed, depending on
@@ -674,16 +673,16 @@ void cb_btle(ubertooth_t* ut, void* args, usb_pkt_rx *rx, int bank __attribute__
 					sig, noise,
 					refAA, pkt);
 		lell_pcap_append_ppi_packet(h_pcap_le, nowns,
-					    rx->clkn_high, 
-					    rx->rssi_min, rx->rssi_max,
-					    rx->rssi_avg, rx->rssi_count,
-					    pkt);
+		                            rx->clkn_high,
+		                            rx->rssi_min, rx->rssi_max,
+		                            rx->rssi_avg, rx->rssi_count,
+		                            pkt);
 	}
 #endif
 	if (h_pcapng_le) {
 		lell_pcapng_append_packet(h_pcapng_le, nowns,
-					  sig, noise,
-					  refAA, pkt);
+		                          sig, noise,
+		                          refAA, pkt);
 	}
 
 	// rollover
@@ -756,7 +755,7 @@ static void cb_dump_bitstream(ubertooth_t* ut, void* args __attribute__((unused)
 	if (dumpfile == NULL) {
 		if (fwrite(ut->br_symbols[bank], sizeof(u8), BANK_LEN, stdout) != 1) {;}
 		fwrite(&nl, sizeof(u8), 1, stdout);
-    } else {
+	} else {
 		if (fwrite(ut->br_symbols[bank], sizeof(u8), BANK_LEN, dumpfile) != 1) {;}
 		fwrite(&nl, sizeof(u8), 1, dumpfile);
 	}
@@ -807,7 +806,7 @@ int specan(ubertooth_t* ut, int xfer_size, u16 low_freq,
 
 	while (1) {
 		r = libusb_bulk_transfer(ut->devh, DATA_IN, buffer, xfer_size,
-				&transferred, TIMEOUT);
+		                         &transferred, TIMEOUT);
 		if (r < 0) {
 			fprintf(stderr, "bulk read returned: %d , failed to read\n", r);
 			return r;
@@ -824,10 +823,10 @@ int specan(ubertooth_t* ut, int xfer_size, u16 low_freq,
 
 		/* process each received block */
 		for (i = 0; i < xfer_blocks; i++) {
-			time = buffer[4 + PKT_LEN * i]
-					| (buffer[5 + PKT_LEN * i] << 8)
-					| (buffer[6 + PKT_LEN * i] << 16)
-					| (buffer[7 + PKT_LEN * i] << 24);
+			time = (buffer[4 + PKT_LEN * i]) |
+			       (buffer[5 + PKT_LEN * i] << 8) |
+			       (buffer[6 + PKT_LEN * i] << 16) |
+			       (buffer[7 + PKT_LEN * i] << 24);
 			if(debug)
 				fprintf(stderr, "rx block timestamp %u * 100 nanoseconds\n", time);
 			for (j = PKT_LEN * i + SYM_OFFSET; j < PKT_LEN * i + 62; j += 3) {
@@ -841,18 +840,18 @@ int specan(ubertooth_t* ut, int xfer_size, u16 low_freq,
 							break;
 						case SPECAN_STDOUT:
 							printf("%f, %d, %d\n", ((double)time)/10000000,
-								frequency, buffer[j + 2]);
+							       frequency, buffer[j + 2]);
 							break;
 						case SPECAN_GNUPLOT_NORMAL:
 							printf("%d %d\n", frequency, buffer[j + 2]);
 							break;
 						case SPECAN_GNUPLOT_3D:
 							printf("%f %d %d\n", ((double)time)/10000000,
-								frequency, buffer[j + 2]);
+							       frequency, buffer[j + 2]);
 							break;
 						default:
 							fprintf(stderr, "Unrecognised output mode (%d)\n",
-									output_mode);
+							        output_mode);
 							return -1;
 							break;
 					}
@@ -912,6 +911,7 @@ ubertooth_t* ubertooth_init()
 	ubertooth_t* ut = (ubertooth_t*)malloc(sizeof(ubertooth_t));
 	if(ut == NULL) {
 		fprintf(stderr, "Unable to allocate memory\n");
+		return NULL;
 	}
 
 	ut->devh = NULL;

--- a/host/libubertooth/src/ubertooth.h
+++ b/host/libubertooth/src/ubertooth.h
@@ -23,6 +23,7 @@
 #define __UBERTOOTH_H__
 
 #include "ubertooth_control.h"
+#include "ubertooth_ringbuffer.h"
 #include <btbb.h>
 
 /* specan output types
@@ -41,6 +42,8 @@ enum board_ids {
 };
 
 typedef struct {
+	/* Ringbuffers for USB and Bluetooth symbols */
+	ringbuffer_t* packets;
 	usb_pkt_rx usb_packets[NUM_BANKS];
 	char br_symbols[NUM_BANKS][BANK_LEN];
 
@@ -59,7 +62,7 @@ typedef struct {
 	btbb_piconet* follow_pn;
 } ubertooth_t;
 
-typedef void (*rx_callback)(ubertooth_t* ut, void* args, usb_pkt_rx *rx, int bank);
+typedef void (*rx_callback)(ubertooth_t* ut, void* args);
 
 typedef struct {
 	unsigned allowed_access_address_errors;
@@ -81,8 +84,8 @@ void rx_file(FILE* fp, btbb_piconet* pn);
 void rx_dump(ubertooth_t* ut, int full);
 void rx_btle(ubertooth_t* ut);
 void rx_btle_file(FILE* fp);
-void cb_btle(ubertooth_t* ut, void* args, usb_pkt_rx *rx, int bank);
-void cb_ego(ubertooth_t* ut, void* args, usb_pkt_rx *rx, int bank);
+void cb_btle(ubertooth_t* ut, void* args);
+void cb_ego(ubertooth_t* ut, void* args);
 
 #ifdef ENABLE_PCAP
 extern btbb_pcap_handle * h_pcap_bredr;

--- a/host/libubertooth/src/ubertooth.h
+++ b/host/libubertooth/src/ubertooth.h
@@ -71,10 +71,10 @@ ubertooth_t* ubertooth_init();
 ubertooth_t* ubertooth_start(int ubertooth_device);
 void ubertooth_stop(ubertooth_t* ut);
 int specan(ubertooth_t* ut, int xfer_size, u16 low_freq,
-		   u16 high_freq, u8 output_mode);
+           u16 high_freq, u8 output_mode);
 int cmd_ping(struct libusb_device_handle* devh);
 int stream_rx_usb(ubertooth_t* ut, int xfer_size,
-				  rx_callback cb, void* cb_args);
+                  rx_callback cb, void* cb_args);
 int stream_rx_file(FILE* fp, rx_callback cb, void* cb_args);
 void rx_live(ubertooth_t* ut, btbb_piconet* pn, int timeout);
 void rx_file(FILE* fp, btbb_piconet* pn);

--- a/host/libubertooth/src/ubertooth_interface.h
+++ b/host/libubertooth/src/ubertooth_interface.h
@@ -22,7 +22,11 @@
 #ifndef __UBERTOOTH_INTERFACE_H
 #define __UBERTOOTH_INTERFACE_H
 
+#include <stdint.h>
+
 #define DMA_SIZE 50
+
+#define NUM_BREDR_CHANNELS 79
 
 enum ubertooth_usb_commands {
     UBERTOOTH_PING            = 0,

--- a/host/libubertooth/src/ubertooth_ringbuffer.c
+++ b/host/libubertooth/src/ubertooth_ringbuffer.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015 Hannes Ellinger
+ *
+ * This file is part of Project Ubertooth.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ubertooth_ringbuffer.h"
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+static void unpack_symbols(const uint8_t* buf, char* unpacked)
+{
+	int i, j;
+
+
+	for (i = 0; i < SYM_LEN; i++) {
+		/* output one byte for each received symbol (0x00 or 0x01) */
+		for (j = 0; j < 8; j++) {
+			unpacked[i * 8 + j] = ((buf[i] << j) & 0x80) >> 7;
+		}
+	}
+}
+
+ringbuffer_t* ringbuffer_init()
+{
+	ringbuffer_t* rb = (ringbuffer_t*)malloc(sizeof(ringbuffer_t));
+
+	rb->current_bank = 0;
+
+	return rb;
+}
+
+int ringbuffer_add(ringbuffer_t* rb, const usb_pkt_rx* rx)
+{
+	if(rx->pkt_type == KEEP_ALIVE)
+		return 1;
+
+	/* Check if channel is valid */
+	if (rx->channel > (NUM_BREDR_CHANNELS-1))
+		return -1;
+
+	rb->current_bank = (rb->current_bank + 1) % NUM_BANKS;
+
+	/* Copy packet (for dump) */
+	memcpy(ringbuffer_top_usb(rb), rx, sizeof(usb_pkt_rx));
+
+	unpack_symbols(ringbuffer_top_usb(rb)->data, ringbuffer_top_bt(rb));
+
+	return 0;
+}
+
+
+usb_pkt_rx* ringbuffer_get_usb(ringbuffer_t* rb, uint8_t index)
+{
+	return &(rb->usb[(rb->current_bank+1+index) % NUM_BANKS]);
+}
+usb_pkt_rx* ringbuffer_top_usb(ringbuffer_t* rb)
+{
+	return ringbuffer_get_usb(rb, NUM_BANKS-1);
+}
+
+usb_pkt_rx* ringbuffer_bottom_usb(ringbuffer_t* rb)
+{
+	return ringbuffer_get_usb(rb, 0);
+}
+
+char* ringbuffer_get_bt(ringbuffer_t* rb, uint8_t index)
+{
+	return rb->bt[(rb->current_bank+1+index) % NUM_BANKS];
+}
+
+char* ringbuffer_top_bt(ringbuffer_t* rb)
+{
+	return ringbuffer_get_bt(rb, NUM_BANKS-1);
+}
+
+char* ringbuffer_bottom_bt(ringbuffer_t* rb)
+{
+	return ringbuffer_get_bt(rb, 0);
+}

--- a/host/libubertooth/src/ubertooth_ringbuffer.h
+++ b/host/libubertooth/src/ubertooth_ringbuffer.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 Hannes Ellinger
+ *
+ * This file is part of Project Ubertooth.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __UBERTOOTH_RINGBUFFER_H__
+#define __UBERTOOTH_RINGBUFFER_H__
+
+#include "ubertooth_control.h"
+
+typedef struct {
+	uint8_t current_bank;
+	usb_pkt_rx usb[NUM_BANKS];
+	char bt[NUM_BANKS][BANK_LEN];
+} ringbuffer_t;
+
+ringbuffer_t* ringbuffer_init();
+
+int ringbuffer_add(ringbuffer_t* rb, const usb_pkt_rx* rx);
+
+usb_pkt_rx* ringbuffer_get_usb(ringbuffer_t* rb, uint8_t index);
+usb_pkt_rx* ringbuffer_top_usb(ringbuffer_t* rb);
+usb_pkt_rx* ringbuffer_bottom_usb(ringbuffer_t* rb);
+char* ringbuffer_get_bt(ringbuffer_t* rb, uint8_t index);
+char* ringbuffer_top_bt(ringbuffer_t* rb);
+char* ringbuffer_bottom_bt(ringbuffer_t* rb);
+
+#endif /* __UBERTOOTH_RINGBUFFER_H__ */

--- a/host/ubertooth-tools/src/ubertooth-btle.c
+++ b/host/ubertooth-tools/src/ubertooth-btle.c
@@ -244,7 +244,7 @@ int main(int argc, char *argv[])
 	}
 
 	if (do_follow || do_promisc) {
-		usb_pkt_rx pkt;
+		usb_pkt_rx rx;
 
 		int r = cmd_set_jam_mode(ut->devh, jam_mode);
 		if (jam_mode != JAM_NONE && r != 0) {
@@ -268,13 +268,15 @@ int main(int argc, char *argv[])
 		}
 
 		while (1) {
-			int r = cmd_poll(ut->devh, &pkt);
+			int r = cmd_poll(ut->devh, &rx);
 			if (r < 0) {
 				printf("USB error\n");
 				break;
 			}
-			if (r == sizeof(usb_pkt_rx))
-				cb_btle(ut, &cb_opts, &pkt, 0);
+			if (r == sizeof(usb_pkt_rx)) {
+				ringbuffer_add(ut->packets, &rx);
+				cb_btle(ut, &cb_opts);
+			}
 			usleep(500);
 		}
 		ubertooth_stop(ut);

--- a/host/ubertooth-tools/src/ubertooth-dfu.c
+++ b/host/ubertooth-tools/src/ubertooth-dfu.c
@@ -1,19 +1,19 @@
 /* -*- c -*- */
 /*
  * Copyright 2015 Dominic Spill
- * 
+ *
  * This file is part of Project Ubertooth
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2, or (at your option)
  * any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with libbtbb; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -44,25 +44,25 @@ static uint32_t crc32(uint8_t *data, uint32_t data_len) {
 static int check_suffix(FILE* signedfile, DFU_suffix* suffix) {
 	uint8_t *data;
 	uint32_t crc, data_length;
-	
+
 	printf("Checking firmware signature\n");
 	fseek(signedfile, 0, SEEK_END);
 	data_length = ftell(signedfile) - 4; // Ignore 4 byte CRC
 	fseek(signedfile, -16, SEEK_END); // Start of SFU suffix
 	fread(suffix, 1, 16, signedfile);
-	
+
 	if(suffix->bLength != 16) {
 		fprintf(stderr, "Unknown DFU suffix length: %d\n", suffix->bLength);
 		return 1;
 	}
-	
+
 	// We only know about dfu version 1.0/1.1
 	// This needs to be smarter to support other versions if/when they exist
 	if((suffix->bcdDFU != 0x0100) && (suffix->bcdDFU != 0x0101)) {
 		fprintf(stderr, "Unknown DFU version: %04x\n", suffix->bcdDFU);
 		return 1;
 	}
-	
+
 	// Suffix bytes are reversed
 	if(!((suffix->ucDfuSig[0]==0x55) &&
 		 (suffix->ucDfuSig[1]==0x46) &&
@@ -70,14 +70,14 @@ static int check_suffix(FILE* signedfile, DFU_suffix* suffix) {
 		fprintf(stderr, "DFU Signature mismatch: not a DFU file\n");
 		return 1;
 	}
-	
+
 	fseek(signedfile, 0, SEEK_SET);
 	data = malloc(data_length);
 	if(data == NULL) {
 		fprintf(stderr, "Cannot allocate buffer for CRC check\n");
 		return 1;
 	}
-	
+
 	data_length = fread(data, 1, data_length, signedfile);
 	crc = crc32(data, data_length);
 	free(data);
@@ -95,7 +95,7 @@ int sign(FILE* infile, FILE* outfile, uint16_t idVendor, uint16_t idProduct) {
 	DFU_suffix* suffix;
 	uint32_t data_length, buffer_length;
 	uint8_t* buffer;
-	
+
 	fseek(infile, 0, SEEK_END);
 	data_length = ftell(infile);
 	buffer_length = data_length + sizeof(DFU_suffix); // Add suffix
@@ -104,10 +104,10 @@ int sign(FILE* infile, FILE* outfile, uint16_t idVendor, uint16_t idProduct) {
 		fprintf(stderr, "Cannot allocate buffer to calculate CRC\n");
 		return 1;
 	}
-	
+
 	fseek(infile, 0, SEEK_SET);
 	data_length = fread(buffer, 1, data_length, infile);
-	
+
 	suffix = (DFU_suffix *) (buffer + data_length);
 	suffix->idVendor    = idVendor;
 	suffix->idProduct   = idProduct;
@@ -118,7 +118,7 @@ int sign(FILE* infile, FILE* outfile, uint16_t idVendor, uint16_t idProduct) {
 	suffix->ucDfuSig[2] = 0x44;
 	suffix->bLength     = 16;
 	suffix->dwCRC = crc32(buffer, data_length + 12);
-	
+
 	fwrite(buffer, 1, buffer_length, outfile);
 	free(buffer);
 	return 0;
@@ -133,9 +133,9 @@ static struct libusb_device_handle* find_ubertooth_dfu_device() {
 	struct libusb_device_handle *devh = NULL;
 	struct libusb_device_descriptor desc;
 	int usb_devs, i, r, ret;
-	
+
 	r = libusb_init(NULL);
-	
+
 	usb_devs = libusb_get_device_list(ctx, &usb_list);
 	for(i = 0 ; i < usb_devs ; ++i) {
 		r = libusb_get_device_descriptor(usb_list[i], &desc);
@@ -276,18 +276,18 @@ int upload(libusb_device_handle* devh, FILE* upfile) {
 	address = BOOTLOADER_OFFSET + BOOTLOADER_SIZE;
 	length = (256 * 1024) - address;
 	block = address / BLOCK_SIZE;
-	
+
     if ((address & (BLOCK_SIZE - 1)) != 0) {
 		fprintf(stderr, "Upload failed: must start at block boundary\n");
 		return -1;
     }
-	
+
 	rv = enter_dfu_mode(devh);
 	if(rv < 0) {
 		fprintf(stderr, "Upload failed: could not enter DFU mode\n");
 		return rv;
 	}
-	
+
 	while(length > 0) {
 		rv = libusb_control_transfer(devh, DFU_IN, REQ_UPLOAD, block, 0,
 									 buffer, BLOCK_SIZE, 1000);
@@ -335,12 +335,12 @@ int download(libusb_device_handle* devh, FILE* downfile) {
 	address = BOOTLOADER_OFFSET + BOOTLOADER_SIZE;
 	block = address / BLOCK_SIZE;
 	fseek(downfile, 0, SEEK_SET);
-	
+
     if ((address & (SECTOR_SIZE - 1)) != 0) {
 		fprintf(stderr, "Download failed: must start at sector boundary\n");
 		return -1;
     }
-	
+
 	rv = enter_dfu_mode(devh);
 	if(rv < 0) {
 		fprintf(stderr, "Download failed: could not enter DFU mode\n");
@@ -407,7 +407,7 @@ int main(int argc, char **argv) {
 	int opt, ubertooth_device = -1;
 	int r;
 	ubertooth_t* ut = NULL;
-	
+
 	while ((opt=getopt(argc,argv,"hd:u:s:rU:")) != EOF) {
 		switch(opt) {
 		case 'd':
@@ -457,13 +457,13 @@ int main(int argc, char **argv) {
 			return 1;
 		}
 	}
-	
+
 	if(functions & FUNC_SIGN) {
 		sign(infile, outfile, U1_DFU_VENDORID, U1_DFU_PRODUCTID);
 		fclose(infile);
 		fclose(outfile);
 	}
-	
+
 	if(functions & (FUNC_UPLOAD|FUNC_DOWNLOAD|FUNC_RESET)) {
 		// Find Ubertooth and switch it to DFU mode
 		int rv, count= 0;
@@ -488,7 +488,7 @@ int main(int argc, char **argv) {
 			return 1;
 		}
 	}
-	
+
 	if(functions & FUNC_UPLOAD) {
 		int rv;
 		rv = upload(devh, upfile);
@@ -498,7 +498,7 @@ int main(int argc, char **argv) {
 			return rv;
 		}
 	}
-	
+
 	if(functions & FUNC_DOWNLOAD) {
 		int rv;
 		DFU_suffix suffix;
@@ -514,11 +514,11 @@ int main(int argc, char **argv) {
 			return rv;
 		}
 	}
-	
+
 	if(functions & FUNC_RESET) {
 		detach(devh);
 	}
-	
+
 	if(functions & (FUNC_UPLOAD|FUNC_DOWNLOAD|FUNC_RESET)) {
 		stop_device(devh);
 	}

--- a/host/ubertooth-tools/src/ubertooth-ego.c
+++ b/host/ubertooth-tools/src/ubertooth-ego.c
@@ -87,7 +87,7 @@ int main(int argc, char *argv[])
 	register_cleanup_handler(ut);
 
 	if (do_mode >= 0) {
-		usb_pkt_rx pkt;
+		usb_pkt_rx rx;
 
 		if (do_mode == 1) // FIXME magic number!
 			cmd_set_channel(ut->devh, do_channel);
@@ -102,13 +102,15 @@ int main(int argc, char *argv[])
 		}
 
 		while (1) {
-			int r = cmd_poll(ut->devh, &pkt);
+			int r = cmd_poll(ut->devh, &rx);
 			if (r < 0) {
 				printf("USB error\n");
 				break;
 			}
-			if (r == sizeof(usb_pkt_rx))
-				cb_ego(ut, NULL, &pkt, 0);
+			if (r == sizeof(usb_pkt_rx)) {
+				ringbuffer_add(ut->packets, &rx);
+				cb_ego(ut, NULL);
+			}
 			usleep(500);
 		}
 		ubertooth_stop(ut);


### PR DESCRIPTION
This is my next step for modularizing libubertooth. It adds a ringbuffer datastructure to the ubertooth_t structure that stores the received USB packets.

Every USB packet from the Ubertooth stick is added to the ringbuffer when received. The callback functions now work with the entire ringbuffer rather than only the last received USB packet. This is especially handy for ubertooth-rx which searches for Bluetooth packets in the bitstream of multiple USB packets.

The ringbuffer provides a function for adding a USB packet, which also takes care of correctly modifying the buffer indices. It also provides functions that extract and return the Bluetooth bitstream from the USB packets.

As my last big PR, this commit has a lot of changes in code but only few changes in functionality. I successfully tested ubertooth-dfu, ubertooth-rx, ubertooth-dump, ubertooth-specan and ubertooth-scan with my changes. This time I also made sure the kismet plugin still builds correctly.

I also made some changes that modularize and unify the way USB bulk transfer packets are received from the Ubertooth and use the ringbuffer datastructure. I will propose them in a separate PR.

Cheers!

Hannes