### PR TITLE
modularize and unify the way usb bulk transfers are handled in libubertooth

### DIFF
--- a/host/kismet/plugin-ubertooth-phyneutral/packetsource_ubertooth.h
+++ b/host/kismet/plugin-ubertooth-phyneutral/packetsource_ubertooth.h
@@ -104,8 +104,6 @@ protected:
 	// Named USB interface
 	string usb_dev;
 
-	struct libusb_device_handle* devh;
-
 	// FD pipes
 	int fake_fd[2];
 
@@ -118,14 +116,9 @@ protected:
 	// Error from thread
 	string thread_error;
 
-	char symbols[NUM_BANKS][BANK_LEN];
-	int bank;
-	uint8_t rx_buf1[BUFFER_SIZE];
-	uint8_t rx_buf2[BUFFER_SIZE];
+	ubertooth_t* ut;
 
 	unsigned int channel;
-
-	ubertooth_t* ut;
 
 	pthread_mutex_t packet_lock;
 
@@ -140,9 +133,9 @@ protected:
 	void decode_pkt(btbb_packet*, btbb_piconet*);
 
 
-	friend void enqueue(PacketSource_Ubertooth *, btbb_packet *);
-	friend void cb_xfer(struct libusb_transfer *);
-	friend void *ubertooth_cap_thread(void *);
+	friend void enqueue(PacketSource_Ubertooth*, btbb_packet*);
+	friend void cb_xfer(struct libusb_transfer*);
+	friend void* ubertooth_cap_thread(void*);
 };
 
 #endif

--- a/host/kismet/plugin-ubertooth/packetsource_ubertooth.cc
+++ b/host/kismet/plugin-ubertooth/packetsource_ubertooth.cc
@@ -53,7 +53,6 @@ PacketSource_Ubertooth::PacketSource_Ubertooth(GlobalRegistry *in_globalreg, str
 	pending_packet = 0;
 
 	channel = 39;
-	bank = 0;
 
 	ut = ubertooth_init();
 
@@ -90,41 +89,7 @@ int PacketSource_Ubertooth::AutotypeProbe(string in_device) {
 	return 0;
 }
 
-/* bulk transfer callback for libusb */
-void cb_xfer(struct libusb_transfer *xfer)
-{
-	PacketSource_Ubertooth *ubertooth =
-			(PacketSource_Ubertooth *) xfer->user_data;
-	int r;
-	u8 *tmp;
-
-	if (xfer->status != LIBUSB_TRANSFER_COMPLETED) {
-		fprintf(stderr, "ut->rx_xfer status: %d\n", xfer->status);
-		libusb_free_transfer(xfer);
-		ubertooth->ut->rx_xfer = NULL;
-		return;
-	}
-
-	while (ubertooth->ut->usb_really_full)
-		fprintf(stderr, "uh oh, ut->full_usb_buf not emptied\n");
-
-	tmp = ubertooth->ut->full_usb_buf;
-	ubertooth->ut->full_usb_buf = ubertooth->ut->empty_usb_buf;
-	ubertooth->ut->empty_usb_buf = tmp;
-	ubertooth->ut->usb_really_full = 1;
-
-	ubertooth->ut->rx_xfer->buffer = ubertooth->ut->empty_usb_buf;
-
-	while (1) {
-		r = libusb_submit_transfer(ubertooth->ut->rx_xfer);
-		if (r < 0)
-			fprintf(stderr, "ut->rx_xfer submission from callback: %d\n", r);
-		else
-			break;
-	}
-}
-
-void enqueue(PacketSource_Ubertooth *ubertooth, btbb_packet *pkt)
+void enqueue(PacketSource_Ubertooth* ubertooth, btbb_packet* pkt)
 {
 	int write_size;
 
@@ -153,109 +118,45 @@ void enqueue(PacketSource_Ubertooth *ubertooth, btbb_packet *pkt)
 	pthread_mutex_unlock(&(ubertooth->packet_lock));
 }
 
-// Capture thread to fake async io
-void *ubertooth_cap_thread(void *arg)
+static void cb_cap(ubertooth_t* ut, void* args)
 {
-	PacketSource_Ubertooth *ubertooth = (PacketSource_Ubertooth *) arg;
-	int i, j, k, m, r, offset;
-	int xfer_size = 512;
-	int xfer_blocks;
-	uint32_t clkn; /* native (local) clock in 625 us */
+	PacketSource_Ubertooth* ubertooth = (PacketSource_Ubertooth*) args;
+	btbb_packet* pkt = NULL;
+	usb_pkt_rx* rx = ringbuffer_bottom_usb(ut->packets);
 	char syms[BANK_LEN * NUM_BANKS];
-	usb_pkt_rx *rx;
-	uint8_t rx_buf1[BUFFER_SIZE];
-	uint8_t rx_buf2[BUFFER_SIZE];
 
-	/*
-	* A block is 64 bytes transferred over USB (includes 50 bytes of rx symbol
-	* payload).  A transfer consists of one or more blocks.  Consecutive
-	* blocks should be approximately 400 microseconds apart (timestamps about
-	* 4000 apart in units of 100 nanoseconds).
-	*/
+	for (int i = 0; i < NUM_BANKS; i++)
+		memcpy(syms + i * BANK_LEN,
+		       ringbuffer_get_bt(ut->packets, i),
+		       BANK_LEN);
 
-	if (xfer_size > BUFFER_SIZE)
-		xfer_size = BUFFER_SIZE;
-	xfer_blocks = xfer_size / 64;
-	xfer_size = xfer_blocks * 64;
-	fprintf(stderr, "rx blocks of 64 bytes in %d byte transfers\n", xfer_size);
+	int offset = btbb_find_ac(syms, BANK_LEN, LAP_ANY, 1, &pkt);
+	if (offset >= 0) {
 
-	ubertooth->ut->empty_usb_buf = &(rx_buf1[0]);
-	ubertooth->ut->full_usb_buf = &(rx_buf2[0]);
-	ubertooth->ut->usb_really_full = 0;
-	ubertooth->ut->rx_xfer = libusb_alloc_transfer(0);
-	libusb_fill_bulk_transfer(ubertooth->ut->rx_xfer, ubertooth->ut->devh, DATA_IN,
-					ubertooth->ut->empty_usb_buf, xfer_size, cb_xfer, ubertooth, TIMEOUT);
+		uint32_t clkn = (rx->clkn_high << 20) + (le32toh(rx->clk100ns) + offset*10) / 3125;
+
+		btbb_packet_set_data(pkt, syms + offset,
+		                     NUM_BANKS * BANK_LEN - offset,
+		                     rx->channel, clkn);
+
+		enqueue(ubertooth, pkt);
+	}
+}
+
+// Capture thread to fake async io
+void* ubertooth_cap_thread(void* arg)
+{
+	PacketSource_Ubertooth* ubertooth = (PacketSource_Ubertooth*) arg;
+
+	ubertooth_bulk_init(ubertooth->ut);
 
 	cmd_rx_syms(ubertooth->ut->devh);
 
-	r = libusb_submit_transfer(ubertooth->ut->rx_xfer);
-	if (r < 0) {
-			fprintf(stderr, "ut->rx_xfer submission: %d\n", r);
-			goto out;
-	}
-
 	while (ubertooth->thread_active) {
-		while (!ubertooth->ut->usb_really_full) {
-			r = libusb_handle_events(NULL);
-			if (r < 0) {
-				fprintf(stderr, "libusb_handle_events: %d\n", r);
-				goto out;
-			}
-		}
-		/* process each received block */
-		for (i = 0; i < xfer_blocks; i++) {
-			rx = (usb_pkt_rx *)&(ubertooth->ut->full_usb_buf[64 * i]);
-			//fprintf(stderr, "rx block timestamp %u * 100 nanoseconds\n", time);
-			for (j = 0; j < 50; j++) {
-				/* output one byte for each received symbol (0 or 1) */
-				for (k = 0; k < 8; k++) {
-					//printf("%c", (ut->full_usb_buf[j] & 0x80) >> 7 );
-					ubertooth->symbols[ubertooth->bank][j * 8 + k] =
-						(rx->data[j] & 0x80) >> 7;
-					rx->data[j] <<= 1;
-				}
-			}
-
-			/*
-			* Populate syms with enough symbols to run sniff_ac across one
-			* bank (BANK_LEN + AC_LEN).
-			*/
-			m = 0;
-			for (j = 0, k = 0; k < BANK_LEN; k++)
-					syms[m++] = ubertooth->symbols[(j + 1 + ubertooth->bank)
-									% NUM_BANKS][k];
-			for (j = 1, k = 0; k < AC_LEN; k++)
-					syms[m++] = ubertooth->symbols[(j + 1 + ubertooth->bank)
-									% NUM_BANKS][k];
-
-			btbb_packet *pkt;
-			offset = btbb_find_ac(syms, BANK_LEN, LAP_ANY, 1, &pkt);
-			if (offset >= 0) {
-				/*
-				* Populate syms with the remaining banks.  We don't know how
-				* long the packet is, so we assume the maximum length.
-				*/
-				for (j = 1, k = AC_LEN; k < BANK_LEN; k++)
-					syms[m++] = ubertooth->symbols[(j + 1 + ubertooth->bank)
-								% NUM_BANKS][k];
-				for (j = 2; j < NUM_BANKS; j++)
-					for (k = 0; k < BANK_LEN; k++)
-						syms[m++] = ubertooth->symbols[(j + 1 + ubertooth->bank)
-								% NUM_BANKS][k];
-
-				clkn = (rx->clkn_high << 20) + (le32toh(rx->clk100ns) + offset + 1562) / 3125;
-				btbb_packet_set_data(pkt, syms + offset,
-									 NUM_BANKS * BANK_LEN - offset,
-									 rx->channel, clkn);
-				enqueue(ubertooth, pkt);
-			}
-			ubertooth->bank = (ubertooth->bank + 1) % NUM_BANKS;
-		}
-		ubertooth->ut->usb_really_full = 0;
-		fflush(stderr);
+		ubertooth_bulk_wait(ubertooth->ut);
+		ubertooth_bulk_receive(ubertooth->ut, cb_cap, ubertooth);
 	}
 
-out:
 	ubertooth->thread_active = -1;
 	close(ubertooth->fake_fd[1]);
 	ubertooth->fake_fd[1] = -1;

--- a/host/kismet/plugin-ubertooth/packetsource_ubertooth.h
+++ b/host/kismet/plugin-ubertooth/packetsource_ubertooth.h
@@ -118,9 +118,6 @@ protected:
 
 	ubertooth_t* ut;
 
-	char symbols[NUM_BANKS][BANK_LEN];
-	int bank;
-
 	unsigned int channel;
 
 	pthread_mutex_t packet_lock;
@@ -136,9 +133,9 @@ protected:
 	void decode_pkt(btbb_packet*, btbb_piconet*);
 
 
-	friend void enqueue(PacketSource_Ubertooth *, btbb_packet *);
-	friend void cb_xfer(struct libusb_transfer *);
-	friend void *ubertooth_cap_thread(void *);
+	friend void enqueue(PacketSource_Ubertooth*, btbb_packet*);
+	friend void cb_xfer(struct libusb_transfer*);
+	friend void* ubertooth_cap_thread(void*);
 };
 
 #endif

--- a/host/libubertooth/src/ubertooth.c
+++ b/host/libubertooth/src/ubertooth.c
@@ -284,7 +284,7 @@ int ubertooth_bulk_receive(ubertooth_t* ut, rx_callback cb, void* cb_args)
 	}
 }
 
-int stream_rx_usb(ubertooth_t* ut, int xfer_size __attribute__((unused)), rx_callback cb, void* cb_args)
+int stream_rx_usb(ubertooth_t* ut, rx_callback cb, void* cb_args)
 {
 	int r;
 
@@ -558,7 +558,7 @@ void rx_live(ubertooth_t* ut, btbb_piconet* pn, int timeout)
 	if (ut->follow_pn)
 		cmd_set_clock(ut->devh, 0);
 	else {
-		stream_rx_usb(ut, XFER_LEN, cb_br_rx, pn);
+		stream_rx_usb(ut, cb_br_rx, pn);
 		/* Allow pending transfers to finish */
 		sleep(1);
 	}
@@ -571,7 +571,7 @@ void rx_live(ubertooth_t* ut, btbb_piconet* pn, int timeout)
 		cmd_stop(ut->devh);
 		cmd_set_bdaddr(ut->devh, btbb_piconet_get_bdaddr(ut->follow_pn));
 		cmd_start_hopping(ut->devh, btbb_piconet_get_clk_offset(ut->follow_pn));
-		stream_rx_usb(ut, XFER_LEN, cb_br_rx, ut->follow_pn);
+		stream_rx_usb(ut, cb_br_rx, ut->follow_pn);
 	}
 }
 
@@ -777,9 +777,9 @@ static void cb_dump_full(ubertooth_t* ut, void* args __attribute__((unused)))
 void rx_dump(ubertooth_t* ut, int bitstream)
 {
 	if (bitstream)
-		stream_rx_usb(ut, XFER_LEN, cb_dump_bitstream, NULL);
+		stream_rx_usb(ut, cb_dump_bitstream, NULL);
 	else
-		stream_rx_usb(ut, XFER_LEN, cb_dump_full, NULL);
+		stream_rx_usb(ut, cb_dump_full, NULL);
 }
 
 /* Spectrum analyser mode */

--- a/host/libubertooth/src/ubertooth.h
+++ b/host/libubertooth/src/ubertooth.h
@@ -76,6 +76,11 @@ void ubertooth_stop(ubertooth_t* ut);
 int specan(ubertooth_t* ut, int xfer_size, u16 low_freq,
            u16 high_freq, u8 output_mode);
 int cmd_ping(struct libusb_device_handle* devh);
+
+int ubertooth_bulk_init(ubertooth_t* ut);
+void ubertooth_bulk_wait(ubertooth_t* ut);
+int ubertooth_bulk_receive(ubertooth_t* ut, rx_callback cb, void* cb_args);
+
 int stream_rx_usb(ubertooth_t* ut, int xfer_size,
                   rx_callback cb, void* cb_args);
 int stream_rx_file(FILE* fp, rx_callback cb, void* cb_args);

--- a/host/libubertooth/src/ubertooth.h
+++ b/host/libubertooth/src/ubertooth.h
@@ -75,14 +75,12 @@ ubertooth_t* ubertooth_start(int ubertooth_device);
 void ubertooth_stop(ubertooth_t* ut);
 int specan(ubertooth_t* ut, int xfer_size, u16 low_freq,
            u16 high_freq, u8 output_mode);
-int cmd_ping(struct libusb_device_handle* devh);
 
 int ubertooth_bulk_init(ubertooth_t* ut);
 void ubertooth_bulk_wait(ubertooth_t* ut);
 int ubertooth_bulk_receive(ubertooth_t* ut, rx_callback cb, void* cb_args);
 
-int stream_rx_usb(ubertooth_t* ut, int xfer_size,
-                  rx_callback cb, void* cb_args);
+int stream_rx_usb(ubertooth_t* ut, rx_callback cb, void* cb_args);
 int stream_rx_file(FILE* fp, rx_callback cb, void* cb_args);
 void rx_live(ubertooth_t* ut, btbb_piconet* pn, int timeout);
 void rx_file(FILE* fp, btbb_piconet* pn);

--- a/host/libubertooth/src/ubertooth_control.h
+++ b/host/libubertooth/src/ubertooth_control.h
@@ -75,6 +75,7 @@
 #define MIN(a,b) ((a)<(b) ? (a) : (b))
 
 void show_libusb_error(int error_code);
+int cmd_ping(struct libusb_device_handle* devh);
 int cmd_rx_syms(struct libusb_device_handle* devh);
 int cmd_specan(struct libusb_device_handle* devh, u16 low_freq, u16 high_freq);
 int cmd_led_specan(struct libusb_device_handle* devh, u16 rssi_threshold);


### PR DESCRIPTION
In this PR I introduce three new methods that will help to modularize the USB bulk transfers in libubertooth. By now only the function stream_rx_usb() and the kismet plugin make use of them. The latter also uses the ringbuffer datastructure now. Later I will submit  adopted versions of ubertooth-specan and ubertooth-rx and my AFH channel map detector ubertooth-afh.

* ubertooth_bulk_init() submits the bulk transfer
* ubertooth_bulk_wait() waits for USB packets in blocking mode
* ubertooth_bulk_receive() processes the received packets, puts them into the ringbuffer and calls the callback function