### PR TITLE
move pcap handles into ubertooth struct

### DIFF
--- a/host/libubertooth/src/ubertooth.c
+++ b/host/libubertooth/src/ubertooth.c
@@ -825,7 +825,6 @@ ubertooth_t* ubertooth_init()
 	ut->empty_usb_buf = NULL;
 	ut->full_usb_buf = NULL;
 	ut->usb_really_full = 0;
-	ut->usb_retry = 1;
 	ut->stop_ubertooth = 0;
 	ut->abs_start_ns = 0;
 	ut->start_clk100ns = 0;

--- a/host/libubertooth/src/ubertooth.c
+++ b/host/libubertooth/src/ubertooth.c
@@ -38,16 +38,9 @@
 
 
 uint32_t systime;
-u8 debug = 0;
 FILE *infile = NULL;
 FILE *dumpfile = NULL;
 int max_ac_errors = 2;
-#ifdef ENABLE_PCAP
-btbb_pcap_handle * h_pcap_bredr = NULL;
-lell_pcap_handle * h_pcap_le = NULL;
-#endif
-btbb_pcapng_handle * h_pcapng_bredr = NULL;
-lell_pcapng_handle * h_pcapng_le = NULL;
 
 void print_version() {
 	printf("libubertooth %s (%s), libbtbb %s (%s)\n", VERSION, RELEASE,
@@ -519,14 +512,14 @@ static void cb_br_rx(ubertooth_t* ut, void* args)
 
 	/* Dump to PCAP/PCAPNG if specified */
 #ifdef ENABLE_PCAP
-	if (h_pcap_bredr) {
-		btbb_pcap_append_packet(h_pcap_bredr, nowns,
+	if (ut->h_pcap_bredr) {
+		btbb_pcap_append_packet(ut->h_pcap_bredr, nowns,
 		                        signal_level, noise_level,
 		                        lap, uap, pkt);
 	}
 #endif
-	if (h_pcapng_bredr) {
-		btbb_pcapng_append_packet(h_pcapng_bredr, nowns,
+	if (ut->h_pcapng_bredr) {
+		btbb_pcapng_append_packet(ut->h_pcapng_bredr, nowns,
 		                          signal_level, noise_level,
 		                          lap, uap, pkt);
 	}
@@ -568,7 +561,7 @@ void rx_live(ubertooth_t* ut, btbb_piconet* pn, int timeout)
 	if (ut->follow_pn) {
 		ut->stop_ubertooth = 0;
 		ut->usb_really_full = 0;
-		cmd_stop(ut->devh);
+		// cmd_stop(ut->devh);
 		cmd_set_bdaddr(ut->devh, btbb_piconet_get_bdaddr(ut->follow_pn));
 		cmd_start_hopping(ut->devh, btbb_piconet_get_clk_offset(ut->follow_pn));
 		stream_rx_usb(ut, cb_br_rx, ut->follow_pn);
@@ -659,21 +652,21 @@ void cb_btle(ubertooth_t* ut, void* args)
 	refAA = lell_packet_is_data(pkt) ? 0 : 0x8e89bed6;
 	determine_signal_and_noise( rx, &sig, &noise );
 #ifdef ENABLE_PCAP
-	if (h_pcap_le) {
+	if (ut->h_pcap_le) {
 		/* only one of these two will succeed, depending on
 		 * whether PCAP was opened with DLT_PPI or not */
-		lell_pcap_append_packet(h_pcap_le, nowns,
+		lell_pcap_append_packet(ut->h_pcap_le, nowns,
 					sig, noise,
 					refAA, pkt);
-		lell_pcap_append_ppi_packet(h_pcap_le, nowns,
+		lell_pcap_append_ppi_packet(ut->h_pcap_le, nowns,
 		                            rx->clkn_high,
 		                            rx->rssi_min, rx->rssi_max,
 		                            rx->rssi_avg, rx->rssi_count,
 		                            pkt);
 	}
 #endif
-	if (h_pcapng_le) {
-		lell_pcapng_append_packet(h_pcapng_le, nowns,
+	if (ut->h_pcapng_le) {
+		lell_pcapng_append_packet(ut->h_pcapng_le, nowns,
 		                          sig, noise,
 		                          refAA, pkt);
 	}
@@ -795,22 +788,23 @@ void ubertooth_stop(ubertooth_t* ut)
 	libusb_exit(NULL);
 
 #ifdef ENABLE_PCAP
-	if (h_pcap_bredr) {
-		btbb_pcap_close(h_pcap_bredr);
-		h_pcap_bredr = NULL;
+	if (ut->h_pcap_bredr) {
+		btbb_pcap_close(ut->h_pcap_bredr);
+		ut->h_pcap_bredr = NULL;
 	}
-	if (h_pcap_le) {
-		lell_pcap_close(h_pcap_le);
-		h_pcap_le = NULL;
+	if (ut->h_pcap_le) {
+		lell_pcap_close(ut->h_pcap_le);
+		ut->h_pcap_le = NULL;
 	}
 #endif
-	if (h_pcapng_bredr) {
-		btbb_pcapng_close(h_pcapng_bredr);
-		h_pcapng_bredr = NULL;
+
+	if (ut->h_pcapng_bredr) {
+		btbb_pcapng_close(ut->h_pcapng_bredr);
+		ut->h_pcapng_bredr = NULL;
 	}
-	if (h_pcapng_le) {
-		lell_pcapng_close(h_pcapng_le);
-		h_pcapng_le = NULL;
+	if (ut->h_pcapng_le) {
+		lell_pcapng_close(ut->h_pcapng_le);
+		ut->h_pcapng_le = NULL;
 	}
 }
 
@@ -838,6 +832,14 @@ ubertooth_t* ubertooth_init()
 	ut->last_clk100ns = 0;
 	ut->clk100ns_upper = 0;
 	ut->follow_pn = NULL;
+
+#ifdef ENABLE_PCAP
+	ut->h_pcap_bredr = NULL;
+	ut->h_pcap_le = NULL;
+#endif
+
+	ut->h_pcapng_bredr = NULL;
+	ut->h_pcapng_le = NULL;
 
 	return ut;
 }

--- a/host/libubertooth/src/ubertooth.h
+++ b/host/libubertooth/src/ubertooth.h
@@ -58,6 +58,14 @@ typedef struct {
 	uint64_t last_clk100ns;
 	uint64_t clk100ns_upper;
 	btbb_piconet* follow_pn;
+
+#ifdef ENABLE_PCAP
+	btbb_pcap_handle * h_pcap_bredr;
+	lell_pcap_handle * h_pcap_le;
+#endif
+
+	btbb_pcapng_handle * h_pcapng_bredr;
+	lell_pcapng_handle * h_pcapng_le;
 } ubertooth_t;
 
 typedef void (*rx_callback)(ubertooth_t* ut, void* args);
@@ -86,10 +94,4 @@ void rx_btle_file(FILE* fp);
 void cb_btle(ubertooth_t* ut, void* args);
 void cb_ego(ubertooth_t* ut, void* args);
 
-#ifdef ENABLE_PCAP
-extern btbb_pcap_handle * h_pcap_bredr;
-extern lell_pcap_handle * h_pcap_le;
-#endif
-extern btbb_pcapng_handle * h_pcapng_bredr;
-extern lell_pcapng_handle * h_pcapng_le;
 #endif /* __UBERTOOTH_H__ */

--- a/host/libubertooth/src/ubertooth.h
+++ b/host/libubertooth/src/ubertooth.h
@@ -50,7 +50,6 @@ typedef struct {
 	uint8_t* empty_usb_buf;
 	uint8_t* full_usb_buf;
 	uint8_t usb_really_full;
-	uint8_t usb_retry;
 
 	uint8_t stop_ubertooth;
 	uint64_t abs_start_ns;

--- a/host/ubertooth-tools/src/ubertooth-btle.c
+++ b/host/ubertooth-tools/src/ubertooth-btle.c
@@ -145,8 +145,8 @@ int main(int argc, char *argv[])
 			ubertooth_device = atoi(optarg);
 			break;
 		case 'r':
-			if (!h_pcapng_le) {
-				if (lell_pcapng_create_file(optarg, "Ubertooth", &h_pcapng_le)) {
+			if (!ut->h_pcapng_le) {
+				if (lell_pcapng_create_file(optarg, "Ubertooth", &ut->h_pcapng_le)) {
 					err(1, "lell_pcapng_create_file: ");
 				}
 			}
@@ -156,8 +156,8 @@ int main(int argc, char *argv[])
 			break;
 #ifdef ENABLE_PCAP
 		case 'q':
-			if (!h_pcap_le) {
-				if (lell_pcap_create_file(optarg, &h_pcap_le)) {
+			if (!ut->h_pcap_le) {
+				if (lell_pcap_create_file(optarg, &ut->h_pcap_le)) {
 					err(1, "lell_pcap_create_file: ");
 				}
 			}
@@ -166,8 +166,8 @@ int main(int argc, char *argv[])
 			}
 			break;
 		case 'c':
-			if (!h_pcap_le) {
-				if (lell_pcap_ppi_create_file(optarg, 0, &h_pcap_le)) {
+			if (!ut->h_pcap_le) {
+				if (lell_pcap_ppi_create_file(optarg, 0, &ut->h_pcap_le)) {
 					err(1, "lell_pcap_ppi_create_file: ");
 				}
 			}

--- a/host/ubertooth-tools/src/ubertooth-follow.c
+++ b/host/ubertooth-tools/src/ubertooth-follow.c
@@ -96,8 +96,8 @@ int main(int argc, char *argv[])
 			ubertooth_device = atoi(optarg);
 			break;
 		case 'r':
-			if (!h_pcapng_bredr) {
-				if (btbb_pcapng_create_file( optarg, "Ubertooth", &h_pcapng_bredr )) {
+			if (!ut->h_pcapng_bredr) {
+				if (btbb_pcapng_create_file( optarg, "Ubertooth", &ut->h_pcapng_bredr )) {
 					err(1, "create_bredr_capture_file: ");
 				}
 			}
@@ -107,8 +107,8 @@ int main(int argc, char *argv[])
 			break;
 #ifdef ENABLE_PCAP
 		case 'q':
-			if (!h_pcap_bredr) {
-				if (btbb_pcap_create_file(optarg, &h_pcap_bredr)) {
+			if (!ut->h_pcap_bredr) {
+				if (btbb_pcap_create_file(optarg, &ut->h_pcap_bredr)) {
 					err(1, "btbb_pcap_create_file: ");
 				}
 			}
@@ -171,7 +171,7 @@ int main(int argc, char *argv[])
 		);
 		str2ba(addr, &bdaddr);
 		printf("Address: %s\n", addr);
-	
+
 		if (hci_devinfo(dev_id, &di) < 0) {
 			perror("Can't get device info");
 			return 1;
@@ -194,13 +194,13 @@ int main(int argc, char *argv[])
 			usage();
 			return 1;
 	}
-	
-	if (h_pcapng_bredr) {
-		btbb_pcapng_record_bdaddr(h_pcapng_bredr,
-								  (((uint32_t)uap)<<24)|lap,
-								  0xff, 0);
+
+	if (ut->h_pcapng_bredr) {
+		btbb_pcapng_record_bdaddr(ut->h_pcapng_bredr,
+		                            (((uint32_t)uap)<<24)|lap,
+		                            0xff, 0);
 	}
-	
+
 	//Experimental AFH map reading from remote device
 	if(afh_enabled) {
 		if(hci_read_afh_map(sock, handle, &mode, afh_map, 1000) < 0) {
@@ -221,10 +221,10 @@ int main(int argc, char *argv[])
 		usleep(10000);
 		hci_disconnect(sock, handle, HCI_OE_USER_ENDED_CONNECTION, 10000);
 	}
-	
+
 	/* Clean up on exit. */
 	register_cleanup_handler(ut);
-	
+
 	ut = ubertooth_start(ubertooth_device);
 	if (ut == NULL) {
 		usage();

--- a/host/ubertooth-tools/src/ubertooth-rx.c
+++ b/host/ubertooth-tools/src/ubertooth-rx.c
@@ -84,8 +84,8 @@ int main(int argc, char *argv[])
 			ubertooth_device = atoi(optarg);
 			break;
 		case 'r':
-			if (!h_pcapng_bredr) {
-				if (btbb_pcapng_create_file( optarg, "Ubertooth", &h_pcapng_bredr )) {
+			if (!ut->h_pcapng_bredr) {
+				if (btbb_pcapng_create_file( optarg, "Ubertooth", &ut->h_pcapng_bredr )) {
 					err(1, "create_bredr_capture_file: ");
 				}
 			}
@@ -95,8 +95,8 @@ int main(int argc, char *argv[])
 			break;
 #ifdef ENABLE_PCAP
 		case 'q':
-			if (!h_pcap_bredr) {
-				if (btbb_pcap_create_file(optarg, &h_pcap_bredr)) {
+			if (!ut->h_pcap_bredr) {
+				if (btbb_pcap_create_file(optarg, &ut->h_pcap_bredr)) {
 					err(1, "btbb_pcap_create_file: ");
 				}
 			}
@@ -136,8 +136,8 @@ int main(int argc, char *argv[])
 		btbb_init_piconet(pn, lap);
 		if (have_uap)
 			btbb_piconet_set_uap(pn, uap);
-		if (h_pcapng_bredr) {
-			btbb_pcapng_record_bdaddr(h_pcapng_bredr,
+		if (ut->h_pcapng_bredr) {
+			btbb_pcapng_record_bdaddr(ut->h_pcapng_bredr,
 						  (((uint32_t)uap)<<24)|lap,
 						  have_uap ? 0xff : 0x00, 0);
 		}


### PR DESCRIPTION
This patch moves the global pcap handles into the ubertooth structure. Now multiple ubertooth sticks can dump their traffic to separate pcap files.