### PR TITLE
fix dumpfile support

### DIFF
--- a/host/libubertooth/src/ubertooth.c
+++ b/host/libubertooth/src/ubertooth.c
@@ -310,14 +310,10 @@ static int stream_rx_usb(ubertooth_t* ut, rx_callback cb, void* cb_args)
 }
 
 /* file should be in full USB packet format (ubertooth-dump -f) */
-static int stream_rx_file(FILE* fp, rx_callback cb, void* cb_args)
+int stream_rx_file(ubertooth_t* ut, FILE* fp, rx_callback cb, void* cb_args)
 {
 	uint8_t buf[BUFFER_SIZE];
 	size_t nitems;
-
-	ubertooth_t* ut = ubertooth_init();
-	if (ut == NULL)
-		return -1;
 
 	while(1) {
 		uint32_t systime_be;
@@ -447,12 +443,21 @@ void rx_file(FILE* fp, btbb_piconet* pn)
 	int r = btbb_init(max_ac_errors);
 	if (r < 0)
 		return;
-	stream_rx_file(fp, cb_br_rx, pn);
+
+	ubertooth_t* ut = ubertooth_init();
+	if (ut == NULL)
+		return;
+
+	stream_rx_file(ut, fp, cb_br_rx, pn);
 }
 
 void rx_btle_file(FILE* fp)
 {
-	stream_rx_file(fp, cb_btle, NULL);
+	ubertooth_t* ut = ubertooth_init();
+	if (ut == NULL)
+		return;
+
+	stream_rx_file(ut, fp, cb_btle, NULL);
 }
 
 static void cb_dump_bitstream(ubertooth_t* ut, void* args __attribute__((unused)))

--- a/host/libubertooth/src/ubertooth.h
+++ b/host/libubertooth/src/ubertooth.h
@@ -89,6 +89,8 @@ int ubertooth_bulk_init(ubertooth_t* ut);
 void ubertooth_bulk_wait(ubertooth_t* ut);
 int ubertooth_bulk_receive(ubertooth_t* ut, rx_callback cb, void* cb_args);
 
+int stream_rx_file(ubertooth_t* ut,FILE* fp, rx_callback cb, void* cb_args);
+
 void rx_live(ubertooth_t* ut, btbb_piconet* pn, int timeout);
 void rx_file(FILE* fp, btbb_piconet* pn);
 void rx_dump(ubertooth_t* ut, int full);

--- a/host/ubertooth-tools/src/ubertooth-rx.c
+++ b/host/ubertooth-tools/src/ubertooth-rx.c
@@ -149,6 +149,10 @@ int main(int argc, char* argv[])
 		return 1;
 	}
 
+	r = btbb_init(max_ac_errors);
+	if (r < 0)
+		return r;
+
 	if(survey_mode) {
 		btbb_init_survey();
 	} else {
@@ -182,10 +186,6 @@ int main(int argc, char* argv[])
 		/* Clean up on exit. */
 		register_cleanup_handler(ut);
 
-		r = btbb_init(max_ac_errors);
-		if (r < 0)
-			return r;
-
 		if (timeout)
 			ubertooth_set_timeout(ut, timeout);
 
@@ -207,7 +207,7 @@ int main(int argc, char* argv[])
 
 		ubertooth_stop(ut);
 	} else {
-		rx_file(infile, pn);
+		stream_rx_file(ut, infile, cb_rx, pn);
 		fclose(infile);
 	}
 
@@ -226,6 +226,8 @@ int main(int argc, char* argv[])
 			//btbb_print_afh_map(pn);
 		}
 	}
+	if(dumpfile != NULL)
+		fclose(dumpfile);
 
 	return 0;
 }


### PR DESCRIPTION
I noticed that I broke the infile/dumpfile support in ubertooth-rx. Here is a fix.

I'm not completely lucky with it. I think infile and dumpfile should be a member of the ubertooth_t structure so each ubertooth can have its own dumpfiles and infiles. What do you think?