### PR TITLE
Print scan results when ubertooth-scan is terminated via CTRL+C

### DIFF
--- a/host/libubertooth/src/ubertooth.c
+++ b/host/libubertooth/src/ubertooth.c
@@ -54,10 +54,8 @@ void print_version() {
 ubertooth_t* cleanup_devh = NULL;
 static void cleanup(int sig __attribute__((unused)))
 {
-	if (cleanup_devh) {
-		ubertooth_stop(cleanup_devh);
-	}
-	exit(0);
+	if (cleanup_devh)
+		cleanup_devh->stop_ubertooth = 1;
 }
 
 void register_cleanup_handler(ubertooth_t* ut) {

--- a/host/libubertooth/src/ubertooth.c
+++ b/host/libubertooth/src/ubertooth.c
@@ -299,12 +299,13 @@ static int stream_rx_usb(ubertooth_t* ut, rx_callback cb, void* cb_args)
 		return r;
 
 	// receive and process each packet
-	while(1) {
+	while(!ut->stop_ubertooth) {
 		ubertooth_bulk_wait(ut);
 		r = ubertooth_bulk_receive(ut, cb, cb_args);
 		if (r == 1)
 			return 1;
 	}
+	return 0;
 }
 
 /* file should be in full USB packet format (ubertooth-dump -f) */

--- a/host/libubertooth/src/ubertooth_callback.h
+++ b/host/libubertooth/src/ubertooth_callback.h
@@ -33,5 +33,6 @@ void cb_afh_r(ubertooth_t* ut, void* args);
 void cb_btle(ubertooth_t* ut, void* args);
 void cb_ego(ubertooth_t* ut, void* args __attribute__((unused)));
 void cb_rx(ubertooth_t* ut, void* args);
+void cb_scan(ubertooth_t* ut, void* args);
 
 #endif /* __UBERTOOTH_CALLBACK_H__ */


### PR DESCRIPTION
As @maximcherny wrote in #155 the scan results are not printed when a host program is terminated via CTRL+C. This commit adds this feature by not simply terminating the application on CTRL+C but setting stop_ubertooth and letting the host programs handle the cleanup process by themselves.

I also created a specific callback function for ubertooth-scan.