### PR TITLE
Fix the bug that prevents ubertooth-rx from following

### DIFF
--- a/firmware/bluetooth_rxtx/Makefile
+++ b/firmware/bluetooth_rxtx/Makefile
@@ -8,6 +8,10 @@ SRC = $(TARGET).c \
 	bluetooth.c \
 	bluetooth_le.c \
 	ubertooth_usb.c \
+	ubertooth_rssi.c \
+	ubertooth_cs.c \
+	ubertooth_clock.c \
+	ubertooth_dma.c \
 	cc2400_rangetest.c \
 	ego.c \
 	$(LIBS_PATH)/usb_serial.c \

--- a/firmware/bluetooth_rxtx/bluetooth_rxtx.c
+++ b/firmware/bluetooth_rxtx/bluetooth_rxtx.c
@@ -1483,10 +1483,10 @@ void bt_le_sync(u8 active_mode)
 
 		const uint32_t *whit = whitening_word[btle_channel_index(channel-2402)];
 		for (i = 0; i < 4; i+= 4) {
-			uint32_t v = active_rxbuf[i+0] << 24
-					   | active_rxbuf[i+1] << 16
-					   | active_rxbuf[i+2] << 8
-					   | active_rxbuf[i+3] << 0;
+			uint32_t v = rxbuf1[i+0] << 24
+					   | rxbuf1[i+1] << 16
+					   | rxbuf1[i+2] << 8
+					   | rxbuf1[i+3] << 0;
 			packet[i/4+1] = rbit(v) ^ whit[i/4];
 		}
 
@@ -1498,7 +1498,7 @@ void bt_le_sync(u8 active_mode)
 		// this allows us enough time to resume RX for subsequent packets on the same channel
 		unsigned total_transfers = ((len + 3) + 4 - 1) / 4;
 		if (total_transfers < 11) {
-			while (DMACC0DestAddr < (uint32_t)active_rxbuf + 4 * total_transfers && rx_err == 0)
+			while (DMACC0DestAddr < (uint32_t)rxbuf1 + 4 * total_transfers && rx_err == 0)
 				;
 		} else { // max transfers? just wait till DMA's done
 			while (DMACC0Config & DMACCxConfig_E && rx_err == 0)
@@ -1511,10 +1511,10 @@ void bt_le_sync(u8 active_mode)
 
 		// unwhiten the rest of the packet
 		for (i = 4; i < 44; i += 4) {
-			uint32_t v = active_rxbuf[i+0] << 24
-					   | active_rxbuf[i+1] << 16
-					   | active_rxbuf[i+2] << 8
-					   | active_rxbuf[i+3] << 0;
+			uint32_t v = rxbuf1[i+0] << 24
+					   | rxbuf1[i+1] << 16
+					   | rxbuf1[i+2] << 8
+					   | rxbuf1[i+3] << 0;
 			packet[i/4+1] = rbit(v) ^ whit[i/4];
 		}
 

--- a/firmware/bluetooth_rxtx/bluetooth_rxtx.c
+++ b/firmware/bluetooth_rxtx/bluetooth_rxtx.c
@@ -688,6 +688,9 @@ void TIMER0_IRQHandler()
 			}
 		}
 
+		if(clk100ns_offset > 3124)
+			clkn += 2;
+
 		T0MR0 = 3124 + clk100ns_offset;
 		clk100ns_offset = 0;
 

--- a/firmware/bluetooth_rxtx/bluetooth_rxtx.c
+++ b/firmware/bluetooth_rxtx/bluetooth_rxtx.c
@@ -2090,6 +2090,7 @@ void specan()
 	RXLED_SET;
 
 	queue_init();
+	clkn_start();
 
 #ifdef UBERTOOTH_ONE
 	PAEN_SET;

--- a/firmware/bluetooth_rxtx/ubertooth_clock.c
+++ b/firmware/bluetooth_rxtx/ubertooth_clock.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015 Hannes Ellinger
+ *
+ * This file is part of Project Ubertooth.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ubertooth_clock.h"
+#include "ubertooth.h"
+
+void clkn_stop()
+{
+	/* stop and reset the timer to zero */
+	T0TCR = TCR_Counter_Reset;
+
+	clkn = 0;
+	last_hop = 0;
+
+	clkn_offset = 0;
+	clk100ns_offset = 0;
+}
+
+void clkn_start()
+{
+	/* start timer */
+	T0TCR = TCR_Counter_Enable;
+}
+
+void clkn_init()
+{
+	/*
+	 * Because these are reset defaults, we're assuming TIMER0 is powered on
+	 * and in timer mode.  The TIMER0 peripheral clock should have been set by
+	 * clock_start().
+	 */
+
+	clkn_stop();
+
+#ifdef TC13BADGE
+	/*
+	 * The peripheral clock has a period of 33.3ns.  3 pclk periods makes one
+	 * CLK100NS period (100 ns).
+	 */
+	T0PR = 2;
+#else
+	/*
+	 * The peripheral clock has a period of 20ns.  5 pclk periods
+	 * makes one CLK100NS period (100 ns).
+	 */
+	T0PR = 4;
+#endif
+	/* 3125 * 100 ns = 312.5 us, the Bluetooth clock (CLKN). */
+	T0MR0 = 3124;
+	T0MCR = TMCR_MR0R | TMCR_MR0I;
+	ISER0 = ISER0_ISE_TIMER0;
+}

--- a/firmware/bluetooth_rxtx/ubertooth_clock.h
+++ b/firmware/bluetooth_rxtx/ubertooth_clock.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 Hannes Ellinger
+ *
+ * This file is part of Project Ubertooth.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __UBERTOOTH_CLOCK_H
+#define __UBERTOOTH_CLOCK_H value
+
+#include "inttypes.h"
+
+/*
+ * CLK100NS is a free-running clock with a period of 100 ns.  It resets every
+ * 2^15 * 10^5 cycles (about 5.5 minutes) - computed from clkn and timer0 (T0TC)
+ *
+ * clkn is the native (local) clock as defined in the Bluetooth specification.
+ * It advances 3200 times per second.  Two clkn periods make a Bluetooth time
+ * slot.
+ */
+volatile uint32_t clkn;
+volatile uint32_t last_hop;
+
+volatile uint32_t clkn_offset;
+volatile uint16_t clk100ns_offset;
+
+#define CLK100NS (3125*(clkn & 0xfffff) + T0TC)
+#define LE_BASECLK (12500)                    // 1.25 ms in units of 100ns
+
+void clkn_stop();
+void clkn_start();
+void clkn_init();
+
+#endif

--- a/firmware/bluetooth_rxtx/ubertooth_cs.c
+++ b/firmware/bluetooth_rxtx/ubertooth_cs.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015 Hannes Ellinger
+ *
+ * This file is part of Project Ubertooth.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ubertooth_cs.h"
+#include "ubertooth.h"
+#include "ubertooth_rssi.h"
+
+typedef enum {
+	CS_SAMPLES_1 = 1,
+	CS_SAMPLES_2 = 2,
+	CS_SAMPLES_4 = 3,
+	CS_SAMPLES_8 = 4,
+} cs_samples_t;
+
+#define CS_THRESHOLD_DEFAULT (int8_t)(-120)
+
+
+/* Set CC2400 carrier sense threshold and store value to
+ * global. CC2400 RSSI is determined by 54dBm + level. CS threshold is
+ * in 4dBm steps, so the provided level is rounded to the nearest
+ * multiple of 4 by adding 56. Useful range is -100 to -20. */
+static void cs_threshold_set(int8_t level, cs_samples_t samples)
+{
+	level = level < -120 ? -120 : level;
+	level = level > -20 ? -20 : level;
+	cc2400_set(RSSI, (uint8_t)((level + 56) & (0x3f << 2)) | ((uint8_t)samples&3));
+	cs_threshold_cur = level;
+	cs_no_squelch = (level <= -120);
+}
+
+void cs_threshold_calc_and_set(uint16_t channel)
+{
+	int8_t level;
+
+	/* If threshold is max/avg based (>0), reset here while rx is
+	 * off.  TODO - max-to-iir only works in SWEEP mode, where the
+	 * channel is known to be in the BT band, i.e., rssi_iir has a
+	 * value for it. */
+	if (cs_threshold_req > 0) {
+		int8_t rssi = rssi_get_avg(channel);
+		level = rssi - 54 + cs_threshold_req;
+	} else {
+		level = cs_threshold_req;
+	}
+	cs_threshold_set(level, CS_SAMPLES_4);
+}
+
+/* CS comes from CC2400 GIO6, which is LPC P2.2, active low. GPIO
+ * triggers EINT3, which could be used for other things (but is not
+ * currently). TODO - EINT3 should be managed globally, not turned on
+ * and off here. */
+void cs_trigger_enable(void)
+{
+	cs_trigger = 0;
+	ISER0 = ISER0_ISE_EINT3;
+	IO2IntClr = PIN_GIO6;      // Clear pending
+	IO2IntEnF |= PIN_GIO6;     // Enable port 2.2 falling (CS active low)
+}
+
+void cs_trigger_disable(void)
+{
+	IO2IntEnF &= ~PIN_GIO6;    // Disable port 2.2 falling (CS active low)
+	IO2IntClr = PIN_GIO6;      // Clear pending
+	ICER0 = ICER0_ICE_EINT3;
+	cs_trigger = 0;
+}
+
+void cs_reset(void)
+{
+	cs_trigger_disable();
+
+	cs_no_squelch = 0;
+	cs_threshold_req=CS_THRESHOLD_DEFAULT;
+	cs_threshold_cur=CS_THRESHOLD_DEFAULT;
+}

--- a/firmware/bluetooth_rxtx/ubertooth_cs.h
+++ b/firmware/bluetooth_rxtx/ubertooth_cs.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 Hannes Ellinger
+ *
+ * This file is part of Project Ubertooth.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef UBERTOOTH_CS_H
+#define UBERTOOTH_CS_H
+
+#include "inttypes.h"
+
+#define CS_HOLD_TIME  2      // min pkts to send on trig (>=1)
+
+uint8_t cs_no_squelch;       // rx all packets if set
+int8_t cs_threshold_req;     // requested CS threshold in dBm
+int8_t cs_threshold_cur;     // current CS threshold in dBm
+volatile uint8_t cs_trigger; // set by intr on P2.2 falling (CS)
+
+void cs_threshold_calc_and_set(uint16_t channel);
+void cs_trigger_enable(void);
+void cs_trigger_disable(void);
+void cs_reset(void);
+
+#endif

--- a/firmware/bluetooth_rxtx/ubertooth_dma.c
+++ b/firmware/bluetooth_rxtx/ubertooth_dma.c
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2015 Hannes Ellinger
+ *
+ * This file is part of Project Ubertooth.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ubertooth_dma.h"
+
+#include "ubertooth.h"
+
+/* DMA linked list items */
+typedef struct {
+	uint32_t src;
+	uint32_t dest;
+	uint32_t next_lli;
+	uint32_t control;
+} dma_lli;
+
+dma_lli rx_dma_lli1;
+dma_lli rx_dma_lli2;
+
+dma_lli le_dma_lli[11]; // 11 x 4 bytes
+
+volatile uint8_t rxbuf1[DMA_SIZE];
+volatile uint8_t rxbuf2[DMA_SIZE];
+
+
+static void dma_enable(void)
+{
+	/* enable DMA */
+	DMACC0Config |= DMACCxConfig_E;
+	ISER0 = ISER0_ISE_DMA;
+}
+
+static void dma_disable(void)
+{
+	// disable DMA engine:
+	// refer to UM10360 LPC17xx User Manual Ch 31 Sec 31.6.1, PDF page 607
+
+	// disable DMA interrupts
+	ICER0 = ICER0_ICE_DMA;
+
+	// disable active channels
+	DMACC0Config = 0;
+	DMACC1Config = 0;
+	DMACC2Config = 0;
+	DMACC3Config = 0;
+	DMACC4Config = 0;
+	DMACC5Config = 0;
+	DMACC6Config = 0;
+	DMACC7Config = 0;
+	DMACIntTCClear = 0xFF;
+	DMACIntErrClr = 0xFF;
+
+	// Disable the DMA controller by writing 0 to the DMA Enable bit in the DMACConfig
+	// register.
+	DMACConfig &= ~DMACConfig_E;
+	while (DMACConfig & DMACConfig_E);
+
+	/* reset interrupt counters */
+	rx_tc = 0;
+	rx_err = 0;
+
+	active_rxbuf = &rxbuf1[0];
+	idle_rxbuf = &rxbuf2[0];
+}
+
+void dma_init()
+{
+	/* power up GPDMA controller */
+	PCONP |= PCONP_PCGPDMA;
+
+	dma_disable();
+
+	/* DMA linked lists */
+	rx_dma_lli1.src = (uint32_t)&(DIO_SSP_DR);
+	rx_dma_lli1.dest = (uint32_t)&rxbuf1[0];
+	rx_dma_lli1.next_lli = (uint32_t)&rx_dma_lli2;
+	rx_dma_lli1.control = (DMA_SIZE) |
+			(1 << 12) |        /* source burst size = 4 */
+			(1 << 15) |        /* destination burst size = 4 */
+			(0 << 18) |        /* source width 8 bits */
+			(0 << 21) |        /* destination width 8 bits */
+			DMACCxControl_DI | /* destination increment */
+			DMACCxControl_I;   /* terminal count interrupt enable */
+
+	rx_dma_lli2.src = (uint32_t)&(DIO_SSP_DR);
+	rx_dma_lli2.dest = (uint32_t)&rxbuf2[0];
+	rx_dma_lli2.next_lli = (uint32_t)&rx_dma_lli1;
+	rx_dma_lli2.control = (DMA_SIZE) |
+			(1 << 12) |        /* source burst size = 4 */
+			(1 << 15) |        /* destination burst size = 4 */
+			(0 << 18) |        /* source width 8 bits */
+			(0 << 21) |        /* destination width 8 bits */
+			DMACCxControl_DI | /* destination increment */
+			DMACCxControl_I;   /* terminal count interrupt enable */
+
+	/* enable DMA globally */
+	DMACConfig = DMACConfig_E;
+	while (!(DMACConfig & DMACConfig_E));
+
+	/* configure DMA channel 1 */
+	DMACC0SrcAddr = rx_dma_lli1.src;
+	DMACC0DestAddr = rx_dma_lli1.dest;
+	DMACC0LLI = rx_dma_lli1.next_lli;
+	DMACC0Control = rx_dma_lli1.control;
+	DMACC0Config = DIO_SSP_SRC
+	               | (0x2 << 11)       /* peripheral to memory */
+	               | DMACCxConfig_IE   /* allow error interrupts */
+	               | DMACCxConfig_ITC; /* allow terminal count interrupts */
+}
+
+void dma_init_le()
+{
+	int i;
+
+	/* power up GPDMA controller */
+	PCONP |= PCONP_PCGPDMA;
+
+	dma_disable();
+
+	/* enable DMA globally */
+	DMACConfig = DMACConfig_E;
+	while (!(DMACConfig & DMACConfig_E));
+
+	for (i = 0; i < 11; ++i) {
+		le_dma_lli[i].src = (uint32_t)&(DIO_SSP_DR);
+		le_dma_lli[i].dest = (uint32_t)&rxbuf1[4 * i];
+		le_dma_lli[i].next_lli = i < 10 ? (uint32_t)&le_dma_lli[i+1] : 0;
+		le_dma_lli[i].control = 4 |
+				(1 << 12) |        /* source burst size = 4 */
+				(0 << 15) |        /* destination burst size = 1 */
+				(0 << 18) |        /* source width 8 bits */
+				(0 << 21) |        /* destination width 8 bits */
+				DMACCxControl_DI | /* destination increment */
+				DMACCxControl_I;   /* terminal count interrupt enable */
+	}
+
+	/* configure DMA channel 0 */
+	DMACC0SrcAddr = le_dma_lli[0].src;
+	DMACC0DestAddr = le_dma_lli[0].dest;
+	DMACC0LLI = le_dma_lli[0].next_lli;
+	DMACC0Control = le_dma_lli[0].control;
+	DMACC0Config =
+			DIO_SSP_SRC |
+			(0x2 << 11) |     /* peripheral to memory */
+			DMACCxConfig_IE | /* allow error interrupts */
+			DMACCxConfig_ITC; /* allow terminal count interrupts */
+}
+
+
+void dio_ssp_start()
+{
+	/* make sure the (active low) slave select signal is not active */
+	DIO_SSEL_SET;
+
+	/* enable rx DMA on DIO_SSP */
+	DIO_SSP_DMACR |= SSPDMACR_RXDMAE;
+	DIO_SSP_CR1 |= SSPCR1_SSE;
+
+	dma_enable();
+
+	/* activate slave select pin */
+	DIO_SSEL_CLR;
+}
+
+void dio_ssp_stop()
+{
+	// disable CC2400's output (active low)
+	DIO_SSEL_SET;
+
+	// disable DMA on SSP; disable SSP
+	DIO_SSP_DMACR &= ~SSPDMACR_RXDMAE;
+	DIO_SSP_CR1 &= ~SSPCR1_SSE;
+
+	dma_disable();
+}

--- a/firmware/bluetooth_rxtx/ubertooth_dma.c
+++ b/firmware/bluetooth_rxtx/ubertooth_dma.c
@@ -21,8 +21,6 @@
 
 #include "ubertooth_dma.h"
 
-#include "ubertooth.h"
-
 /* DMA linked list items */
 typedef struct {
 	uint32_t src;
@@ -35,9 +33,6 @@ dma_lli rx_dma_lli1;
 dma_lli rx_dma_lli2;
 
 dma_lli le_dma_lli[11]; // 11 x 4 bytes
-
-volatile uint8_t rxbuf1[DMA_SIZE];
-volatile uint8_t rxbuf2[DMA_SIZE];
 
 
 static void dma_enable(void)

--- a/firmware/bluetooth_rxtx/ubertooth_dma.h
+++ b/firmware/bluetooth_rxtx/ubertooth_dma.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Hannes Ellinger
+ *
+ * This file is part of Project Ubertooth.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __UBERTOOTH_DMA_H
+#define __UBERTOOTH_DMA_H value
+
+#include "inttypes.h"
+
+/*
+ * The active buffer is the one with an active DMA transfer.
+ * The idle buffer is the one we can read/write between transfers.
+ */
+volatile uint8_t* volatile active_rxbuf;
+volatile uint8_t* volatile idle_rxbuf;
+
+/* rx terminal count and error interrupt counters */
+volatile uint32_t rx_tc;
+volatile uint32_t rx_err;
+
+void dma_init();
+void dma_init_le();
+void dio_ssp_start();
+void dio_ssp_stop();
+
+#endif

--- a/firmware/bluetooth_rxtx/ubertooth_dma.h
+++ b/firmware/bluetooth_rxtx/ubertooth_dma.h
@@ -23,6 +23,10 @@
 #define __UBERTOOTH_DMA_H value
 
 #include "inttypes.h"
+#include "ubertooth.h"
+
+volatile uint8_t rxbuf1[DMA_SIZE];
+volatile uint8_t rxbuf2[DMA_SIZE];
 
 /*
  * The active buffer is the one with an active DMA transfer.

--- a/firmware/bluetooth_rxtx/ubertooth_rssi.c
+++ b/firmware/bluetooth_rxtx/ubertooth_rssi.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015 Hannes Ellinger
+ *
+ * This file is part of Project Ubertooth.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ubertooth_rssi.h"
+
+#include <string.h>
+
+#define RSSI_IIR_ALPHA 3       // 3/256 = .012
+
+int32_t rssi_sum;
+int16_t rssi_iir[79] = {0};
+
+void rssi_reset(void)
+{
+	memset(rssi_iir, 0, sizeof(rssi_iir));
+
+	rssi_count = 0;
+	rssi_sum = 0;
+	rssi_max = INT8_MIN;
+	rssi_min = INT8_MAX;
+}
+
+void rssi_add(int8_t v)
+{
+	rssi_max = (v > rssi_max) ? v : rssi_max;
+	rssi_min = (v < rssi_min) ? v : rssi_min;
+	rssi_sum += ((int32_t)v * 256);  // scaled int math (x256)
+	rssi_count += 1;
+}
+
+/* For sweep mode, update IIR per channel. Otherwise, use single value. */
+void rssi_iir_update(uint16_t channel)
+{
+	int32_t avg;
+	int32_t rssi_iir_acc;
+
+	/* Use array to track 79 Bluetooth channels, or just first slot
+	 * of array if the frequency is not a valid Bluetooth channel. */
+	if ( channel < 2402 || channel < 2480 )
+		channel = 2402;
+
+	int i = channel - 2402;
+
+	// IIR using scaled int math (x256)
+	if (rssi_count != 0)
+		avg = (rssi_sum  + 128) / rssi_count;
+	else
+		avg = 0; // really an error
+	rssi_iir_acc = rssi_iir[i] * (256-RSSI_IIR_ALPHA);
+	rssi_iir_acc += avg * RSSI_IIR_ALPHA;
+	rssi_iir[i] = (int16_t)((rssi_iir_acc + 128) / 256);
+}
+
+int8_t rssi_get_avg(uint16_t channel)
+{
+	/* Use array to track 79 Bluetooth channels, or just first slot
+	 * of array if the frequency is not a valid Bluetooth channel. */
+	if ( channel < 2402 || channel < 2480 )
+		channel = 2402;
+
+	return (rssi_iir[channel-2402] + 128) / 256;
+}

--- a/firmware/bluetooth_rxtx/ubertooth_rssi.h
+++ b/firmware/bluetooth_rxtx/ubertooth_rssi.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 Hannes Ellinger
+ *
+ * This file is part of Project Ubertooth.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __UBERTOOTH_RSSI_H
+#define __UBERTOOTH_RSSI_H
+
+#include "inttypes.h"
+
+int8_t rssi_max;
+int8_t rssi_min;
+uint8_t rssi_count;
+
+void rssi_reset(void);
+void rssi_add(int8_t v);
+void rssi_iir_update(uint16_t channel);
+int8_t rssi_get_avg(uint16_t channel);
+
+#endif

--- a/host/libubertooth/src/ubertooth_callback.c
+++ b/host/libubertooth/src/ubertooth_callback.c
@@ -28,7 +28,6 @@
 #include "ubertooth_callback.h"
 
 unsigned int packet_counter_max;
-uint8_t calibrated = 0;
 
 static int8_t cc2400_rssi_to_dbm( const int8_t rssi )
 {
@@ -203,7 +202,7 @@ void cb_br_rx(ubertooth_t* ut, void* args)
 	       snr);
 
 	int r = btbb_process_packet(pkt, pn);
-	
+
 	/* Dump to PCAP/PCAPNG if specified */
 	if (ut->h_pcap_bredr) {
 		btbb_pcap_append_packet(ut->h_pcap_bredr, nowns,
@@ -548,6 +547,9 @@ void cb_rx(ubertooth_t* ut, void* args)
 	uint32_t lap = LAP_ANY;
 	uint8_t uap = UAP_ANY;
 
+	static int trim_counter = 0;
+	static int calibrated = 0;
+
 	/* Do analysis based on oldest packet */
 	usb_pkt_rx* rx = ringbuffer_bottom_usb(ut->packets);
 
@@ -618,18 +620,34 @@ void cb_rx(ubertooth_t* ut, void* args)
 
 	/* calibrate Ubertooth clock such that the first bit of the AC
 	 * arrives CLK_TUNE_TIME after the rising edge of CLKN */
-	if (infile == NULL && !calibrated) {
-		if (clk_offset < CLK_TUNE_TIME) {
+	if (infile == NULL) {
+		if (trim_counter < -PKTS_PER_XFER
+		    || ((clk_offset < CLK_TUNE_TIME - CLK_TUNE_OFFSET) && !calibrated)) {
 			printf("offset < CLK_TUNE_TIME\n");
 			printf("CLK100ns Trim: %d\n", 6250 + clk_offset - CLK_TUNE_TIME);
 			cmd_trim_clock(ut->devh, 6250 + clk_offset - CLK_TUNE_TIME);
-		} else if (clk_offset > CLK_TUNE_TIME) {
+			trim_counter = 0;
+			calibrated = 1;
+			goto out;
+		} else if (trim_counter > PKTS_PER_XFER
+		           || ((clk_offset > CLK_TUNE_TIME + CLK_TUNE_OFFSET) && !calibrated)) {
 			printf("offset > CLK_TUNE_TIME\n");
 			printf("CLK100ns Trim: %d\n", clk_offset - CLK_TUNE_TIME);
 			cmd_trim_clock(ut->devh, clk_offset - CLK_TUNE_TIME);
+			trim_counter = 0;
+			calibrated = 1;
+			goto out;
 		}
-		calibrated = 1;
-		goto out;
+
+		if (clk_offset < CLK_TUNE_TIME - CLK_TUNE_OFFSET) {
+			trim_counter--;
+			goto out;
+		} else if (clk_offset > CLK_TUNE_TIME + CLK_TUNE_OFFSET) {
+			trim_counter++;
+			goto out;
+		} else {
+			trim_counter = 0;
+		}
 	}
 
 	/* If dumpfile is specified, write out all banks to the
@@ -641,7 +659,7 @@ void cb_rx(ubertooth_t* ut, void* args)
 		fwrite(rx, sizeof(usb_pkt_rx), 1, dumpfile);
 		fflush(dumpfile);
 	}
-	
+
 	int r = btbb_process_packet(pkt, pn);
 
 	/* Dump to PCAP/PCAPNG if specified */

--- a/host/libubertooth/src/ubertooth_interface.h
+++ b/host/libubertooth/src/ubertooth_interface.h
@@ -37,6 +37,7 @@
  * CLK_TUNE_TIME * 100 ns prior to the start of an upcoming time slot.
 */
 #define CLK_TUNE_TIME   2250
+#define CLK_TUNE_OFFSET  200
 
 enum ubertooth_usb_commands {
 	UBERTOOTH_PING               = 0,

--- a/host/ubertooth-tools/src/ubertooth-specan.c
+++ b/host/ubertooth-tools/src/ubertooth-specan.c
@@ -34,10 +34,12 @@ void cb_specan(ubertooth_t* ut __attribute__((unused)), void* args)
 	usb_pkt_rx* rx = ringbuffer_top_usb(ut->packets);
 	int r, j;
 	uint16_t frequency;
+	int8_t rssi;
 
 	/* process each received block */
 	for (j = 0; j < DMA_SIZE-2; j += 3) {
 		frequency = (rx->data[j] << 8) | rx->data[j + 1];
+		rssi = (int8_t)rx->data[j + 2];
 		switch(output_mode) {
 			case SPECAN_FILE:
 				r = fwrite(&rx->data[j], 1, 3, dumpfile);
@@ -48,16 +50,16 @@ void cb_specan(ubertooth_t* ut __attribute__((unused)), void* args)
 				break;
 			case SPECAN_STDOUT:
 				printf("%f, %d, %d\n", ((double)rx->clk100ns)/10000000,
-				       frequency, rx->data[j + 2]);
+				       frequency, rssi);
 				break;
 			case SPECAN_GNUPLOT_NORMAL:
-				printf("%d %d\n", frequency, rx->data[j + 2]);
+				printf("%d %d\n", frequency, rssi);
 				if(frequency == high_freq)
 					printf("\n");
 				break;
 			case SPECAN_GNUPLOT_3D:
 				printf("%f %d %d\n", ((double)rx->clk100ns)/10000000,
-				       frequency, rx->data[j + 2]);
+				       frequency, rssi);
 				if(frequency == high_freq)
 					printf("\n");
 				break;


### PR DESCRIPTION
I found out that the firmware does not reset its global variables to their boot-up value when an operation is finished. This caused ubertooth-rx to fail when running it several times without resetting the Ubertooth stick in between.

This patchset resets all global variables to their initial state when entering the IDLE mode. I also modularized the firmware and provided methods for initializing and resetting each module.

I hope this ultimately fixes issue #135, which is already marked as closed.

I tested ubertooth-dump, ubertooth-afh, ubertooth-scan, ubertooth-rx, ubertooth-dfu, ubertooth-specan and ubertooth-util. It seems like the UAP detection performance also has improved. I did not test any btle functions. Could someone do some tests and tell me if anything doesn't work anymore?