### PR TITLE
led-specan: use -dBm as input parameter for rssi threshold

### DIFF
--- a/firmware/bluetooth_rxtx/bluetooth_rxtx.c
+++ b/firmware/bluetooth_rxtx/bluetooth_rxtx.c
@@ -386,7 +386,7 @@ static int vendor_request_handler(uint8_t request, uint16_t* request_params, uin
 	case UBERTOOTH_LED_SPECAN:
 		if (request_params[0] > 256)
 			return 0;
-		rssi_threshold = (int8_t)request_params[0];
+		rssi_threshold = 54 - request_params[0];
 		requested_mode = MODE_LED_SPECAN;
 		*data_len = 0;
 		break;
@@ -2134,7 +2134,7 @@ void led_specan()
 
 		/* give the CC2400 time to acquire RSSI reading */
 		volatile u32 j = 500; while (--j); //FIXME crude delay
-		lvl = cc2400_get(RSSI) >> 8;
+		lvl = (int8_t)((cc2400_get(RSSI) >> 8) & 0xff);
 		if (lvl > rssi_threshold) {
 			switch (i) {
 				case 0:

--- a/host/ubertooth-tools/src/ubertooth-util.c
+++ b/host/ubertooth-tools/src/ubertooth-util.c
@@ -50,7 +50,7 @@ static void usage()
 	printf("\t-m display range test result\n");
 	printf("\t-n initiate range test\n");
 	printf("\t-p get microcontroller Part ID\n");
-	printf("\t-q[1-225 (RSSI threshold)] start LED spectrum analyzer\n");
+	printf("\t-q[RSSI threshold in -dBm] start LED spectrum analyzer\n");
 	printf("\t-r full reset\n");
 	printf("\t-s get microcontroller serial number\n");
 	printf("\t-S stop current operation\n");
@@ -300,8 +300,7 @@ int main(int argc, char *argv[])
 		return cmd_set_isp(ut->devh);
 	}
 	if(do_led_specan >= 0) {
-		do_led_specan= do_led_specan ? do_led_specan : 225;
-		printf("Entering LED specan mode (RSSI %d)\n", do_led_specan);
+		printf("Entering LED specan mode (RSSI -%d dBm)\n", do_led_specan);
 		return cmd_led_specan(ut->devh, do_led_specan);
 	}
 	if(do_range_test == 0) {


### PR DESCRIPTION
Use -dBm as input parameter for rssi threshold since cc2400 has an rssi range of [-120; -20] dBm.