### PR TITLE
Fix for #59: kismet-ubertooth double frees in ubertooth::poll

### DIFF
--- a/host/kismet/plugin-ubertooth/packetsource_ubertooth.cc
+++ b/host/kismet/plugin-ubertooth/packetsource_ubertooth.cc
@@ -353,9 +353,10 @@ int PacketSource_Ubertooth::Poll() {
 
 	pending_packet = 0;
 
-	for (unsigned int x = 0; x < packet_queue.size(); x++) {
+	while (!packet_queue.empty()) {
 		kis_packet *newpack = globalreg->packetchain->GeneratePacket();
-		btbb_packet *pkt = packet_queue[x];
+		btbb_packet *pkt = packet_queue.front();
+		packet_queue.erase(packet_queue.begin());
 
 		newpack->ts.tv_sec = globalreg->timestamp.tv_sec;
 		newpack->ts.tv_usec = globalreg->timestamp.tv_usec;
@@ -402,6 +403,7 @@ int PacketSource_Ubertooth::Poll() {
 
 		// Delete the temp struct
 		btbb_packet_unref(pkt);
+		pkt = NULL;
 	}
 
 	// Flush the queue


### PR DESCRIPTION
Avoid dereferencing a table or vector item in a for loop.
It should be ensured that either while loop are used
or that the for loop is decremented instead of incremented