### PR TITLE
implement a Bluetooth BR transmitter

### DIFF
--- a/firmware/bluetooth_rxtx/bluetooth.c
+++ b/firmware/bluetooth_rxtx/bluetooth.c
@@ -25,8 +25,8 @@
 u8 a1, b, c1, e;
 u16 d1;
 /* frequency register bank */
-u8 bank[CHANNELS];
-u8 afh_bank[CHANNELS];
+u8 bank[NUM_BREDR_CHANNELS];
+u8 afh_bank[NUM_BREDR_CHANNELS];
 
 /* count the number of 1 bits in a uint64_t */
 static uint8_t count_bits(uint64_t n)
@@ -46,8 +46,8 @@ void precalc(void)
 	syncword = 0;
 
 	/* populate frequency register bank*/
-	for (i = 0; i < CHANNELS; i++)
-		bank[i] = ((i * 2) % CHANNELS);
+	for (i = 0; i < NUM_BREDR_CHANNELS; i++)
+		bank[i] = ((i * 2) % NUM_BREDR_CHANNELS);
 		/* actual frequency is 2402 + bank[i] MHz */
 
 
@@ -73,8 +73,8 @@ void precalc(void)
 		for(i = 0; i < 10; i++)
 			used_channels += count_bits((uint64_t) afh_map[i]);
 		j = 0;
-		for (i = 0; i < CHANNELS; i++)
-			chan = (i * 2) % CHANNELS;
+		for (i = 0; i < NUM_BREDR_CHANNELS; i++)
+			chan = (i * 2) % NUM_BREDR_CHANNELS;
 			if(afh_map[chan/8] & (0x1 << (chan % 8)))
 				bank[j++] = chan;
 	}
@@ -145,7 +145,7 @@ u16 next_hop(u32 clock)
 		(y1 * 0x1f) ^ c,
 		d);
 	/* hop selection */
-	next_channel = bank[(perm + e + f + y2) % CHANNELS];
+	next_channel = bank[(perm + e + f + y2) % NUM_BREDR_CHANNELS];
 	if(afh_enabled) {
 		f_dash = base_f % used_channels;
 		next_channel = afh_bank[(perm + e + f_dash + y2) % used_channels];

--- a/firmware/bluetooth_rxtx/bluetooth.c
+++ b/firmware/bluetooth_rxtx/bluetooth.c
@@ -172,7 +172,7 @@ int find_access_code(u8 *idle_rxbuf)
 	// Search until we're 64 symbols from the end of the buffer
 	for(; count < ((8 * DMA_SIZE) - 64); count++)
 	{
-		bit_errors = count_bits(syncword ^ target.access_code);
+		bit_errors = count_bits(syncword ^ target.syncword);
 
 		if (bit_errors < MAX_SYNCWORD_ERRS)
 			return count;

--- a/firmware/bluetooth_rxtx/bluetooth.h
+++ b/firmware/bluetooth_rxtx/bluetooth.h
@@ -25,7 +25,6 @@
 
 #include "ubertooth.h"
 
-#define CHANNELS 79
 #define MAX_SYNCWORD_ERRS 5
 
 bdaddr target;

--- a/firmware/bluetooth_rxtx/bluetooth_rxtx.c
+++ b/firmware/bluetooth_rxtx/bluetooth_rxtx.c
@@ -428,12 +428,12 @@ static int vendor_request_handler(uint8_t request, uint16_t* request_params, uin
 
 	case UBERTOOTH_SET_BDADDR:
 		target.address = 0;
-		target.access_code = 0;
+		target.syncword = 0;
 		for(int i=0; i < 8; i++) {
 			target.address |= (uint64_t)data[i] << 8*i;
 		}
 		for(int i=0; i < 8; i++) {
-			target.access_code |= (uint64_t)data[i+8] << 8*i;
+			target.syncword |= (uint64_t)data[i+8] << 8*i;
 		}
 		precalc();
 		break;
@@ -799,7 +799,7 @@ static void cc2400_idle()
 	rssi_threshold = -30;
 
 	target.address = 0;
-	target.access_code = 0;
+	target.syncword = 0;
 }
 
 /* start un-buffered rx */

--- a/host/libubertooth/src/ubertooth_control.c
+++ b/host/libubertooth/src/ubertooth_control.c
@@ -98,6 +98,11 @@ int cmd_rx_syms(struct libusb_device_handle* devh)
 	return 0;
 }
 
+int cmd_tx_syms(struct libusb_device_handle* devh)
+{
+	return ubertooth_cmd_sync(devh, CTRL_OUT, UBERTOOTH_TX_SYMBOLS, 0, 0);
+}
+
 int cmd_specan(struct libusb_device_handle* devh, u16 low_freq, u16 high_freq)
 {
 	int r;

--- a/host/libubertooth/src/ubertooth_control.h
+++ b/host/libubertooth/src/ubertooth_control.h
@@ -89,6 +89,7 @@ int ubertooth_cmd_async(struct libusb_device_handle* devh,
 void cmd_trim_clock(struct libusb_device_handle* devh, uint16_t offset);
 int cmd_ping(struct libusb_device_handle* devh);
 int cmd_rx_syms(struct libusb_device_handle* devh);
+int cmd_tx_syms(struct libusb_device_handle* devh);
 int cmd_specan(struct libusb_device_handle* devh, u16 low_freq, u16 high_freq);
 int cmd_led_specan(struct libusb_device_handle* devh, u16 rssi_threshold);
 int cmd_set_usrled(struct libusb_device_handle* devh, u16 state);

--- a/host/libubertooth/src/ubertooth_interface.h
+++ b/host/libubertooth/src/ubertooth_interface.h
@@ -168,7 +168,7 @@ typedef struct {
 
 typedef struct {
 	u64    address;
-	u64    access_code;
+	u64    syncword;
 } bdaddr;
 
 typedef struct {

--- a/host/ubertooth-tools/src/CMakeLists.txt
+++ b/host/ubertooth-tools/src/CMakeLists.txt
@@ -59,7 +59,7 @@ if(USE_OWN_GNU_GETOPT)
 	LIST(APPEND TOOLS_LINK_LIBS libgetopt_static)
 endif(USE_OWN_GNU_GETOPT)
 
-LIST(APPEND TOOLS ubertooth-rx ubertooth-dump ubertooth-util ubertooth-btle ubertooth-dfu ubertooth-specan ubertooth-ego ubertooth-afh)
+LIST(APPEND TOOLS ubertooth-rx ubertooth-tx ubertooth-dump ubertooth-util ubertooth-btle ubertooth-dfu ubertooth-specan ubertooth-ego ubertooth-afh)
 
 if( USE_BLUEZ AND NOT ${LIBBLUETOOTH_FOUND} )
 	message( FATAL_ERROR

--- a/host/ubertooth-tools/src/ubertooth-tx.c
+++ b/host/ubertooth-tools/src/ubertooth-tx.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2010, 2011 Michael Ossmann
+ *
+ * This file is part of Project Ubertooth.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ubertooth.h"
+#include "ubertooth_callback.h"
+#include <err.h>
+#include <getopt.h>
+#include <stdlib.h>
+#include <unistd.h>  // sleep
+#include <string.h>
+
+static void usage()
+{
+	printf("ubertooth-rx - passive Bluetooth discovery/decode\n");
+	printf("Usage:\n");
+	printf("\t-h this help\n");
+	printf("\t-V print version information\n");
+	printf("\t-l <LAP> to decode (6 hex), otherwise sniff all LAPs\n");
+	printf("\t-u <UAP> to decode (2 hex), otherwise try to calculate (requires LAP)\n");
+	printf("\t-U <0-7> set ubertooth device to use\n");
+	printf("\t-t <SECONDS> timeout - 0 means no timeout [Default: 0]\n");
+}
+
+int main(int argc, char* argv[])
+{
+	int opt, have_lap = 0, have_uap = 0;
+	int survey_mode = 0;
+	int r;
+	int timeout = 0;
+	int reset_scan = 0;
+	char* end;
+	char ubertooth_device = -1;
+	btbb_piconet* pn = NULL;
+	uint32_t lap = 0;
+	uint8_t uap = 0;
+	uint8_t channel = 39;
+
+	ubertooth_t* ut = ubertooth_init();
+
+	while ((opt=getopt(argc,argv,"hVl:u:U:t:")) != EOF) {
+		switch(opt) {
+		case 'l':
+			lap = strtol(optarg, &end, 16);
+			have_lap++;
+			break;
+		case 'u':
+			uap = strtol(optarg, &end, 16);
+			have_uap++;
+			break;
+		case 'U':
+			ubertooth_device = atoi(optarg);
+			break;
+		case 't':
+			timeout = atoi(optarg);
+			break;
+		case 'V':
+			print_version();
+			return 0;
+		case 'h':
+		default:
+			usage();
+			return 1;
+		}
+	}
+
+	r = ubertooth_connect(ut, ubertooth_device);
+	if (r < 0) {
+		usage();
+		return 1;
+	}
+
+	r = ubertooth_check_api(ut);
+	if (r < 0)
+		return 1;
+
+	if (have_lap && have_uap) {
+		// set bt address
+		r = cmd_set_bdaddr(ut->devh, (((uint32_t)uap)<<24)|lap);
+		if (r < 0)
+			return r;
+		uint64_t syncword = btbb_gen_syncword(lap);
+		printf("Syncword: 0x%016lx\n", syncword);
+	} else {
+		fprintf(stderr, "Error: LAP or UAP not specified\n");
+		usage();
+		return 1;
+	}
+
+	/* Clean up on exit. */
+	register_cleanup_handler(ut, 0);
+
+	if (timeout)
+		ubertooth_set_timeout(ut, timeout);
+
+	// tell ubertooth to send packets
+	r = cmd_tx_syms(ut->devh);
+	if (r < 0)
+		return r;
+
+	// wait
+	while(!ut->stop_ubertooth)
+		sleep(1);
+
+	ubertooth_stop(ut);
+
+	return 0;
+}


### PR DESCRIPTION
Implement a Bluetooth BR simulator that transmits Bluetooth access codes using a Bluetooth hopping scheme. We are using it for examining the detection rate of ubertooth-rx and other BT classic tools.