### PR TITLE
BLE adv channel

### DIFF
--- a/firmware/bluetooth_rxtx/bluetooth_rxtx.c
+++ b/firmware/bluetooth_rxtx/bluetooth_rxtx.c
@@ -520,6 +520,7 @@ static int vendor_request_handler(uint8_t request, uint16_t* request_params, uin
 		do_hop = 0;
 		hop_mode = HOP_BTLE;
 		requested_mode = MODE_BT_FOLLOW_LE;
+		le_adv_channel = channel;
 
 		queue_init();
 		cs_threshold_calc_and_set(channel);

--- a/firmware/bluetooth_rxtx/bluetooth_rxtx.c
+++ b/firmware/bluetooth_rxtx/bluetooth_rxtx.c
@@ -48,7 +48,7 @@ volatile uint16_t channel = 2441;
 volatile uint16_t hop_direct_channel = 0;      // for hopping directly to a channel
 volatile uint16_t hop_timeout = 158;
 volatile uint16_t requested_channel = 0;
-volatile uint16_t saved_request = 0;
+volatile uint16_t le_adv_channel = 0;
 
 /* bulk USB stuff */
 volatile uint8_t  idle_buf_clkn_high = 0;
@@ -798,7 +798,7 @@ static void cc2400_idle()
 	hop_direct_channel = 0;
 	hop_timeout = 158;
 	requested_channel = 0;
-	saved_request = 0;
+	le_adv_channel = 0;
 
 
 	/* bulk USB stuff */
@@ -1612,7 +1612,7 @@ void bt_le_sync(u8 active_mode)
 			/* RX mode */
 			cc2400_strobe(SRX);
 
-			saved_request = requested_channel;
+			le_adv_channel = requested_channel;
 			requested_channel = 0;
 		}
 
@@ -1741,7 +1741,7 @@ void bt_le_sync(u8 active_mode)
 			while ((cc2400_status() & FS_LOCK));
 
 			/* Retune */
-			channel = saved_request != 0 ? saved_request : 2402;
+			channel = le_adv_channel != 0 ? le_adv_channel : 2402;
 			restart_jamming = 1;
 		}
 


### PR DESCRIPTION
I've been using the ubertooth-btle tool and I noticed a bug when doing the -A to select advertising channel and -f for following connections. If you run ubertooth-btle -A 39 -f and it finds a connection which then terminates, it goes back to listen to channel 37 instead of the expected 39.

It seems to me that the saved_request variable can be used to handle this issue but the name is quite vague. I renamed saved_request to le_adv_channel to be a bit more clear and to solve the issue I described above I simply save the current channel in le_adv_channel once the UBERTOOTH_BTLE_SNIFFING command is sent. bt_le_sync() will then retune to le_adv_channel once the connection terminates.
