### PR TITLE
correct linear drift when trimming clk100ns in ubertooth_rx

### DIFF
--- a/firmware/bluetooth_rxtx/ubertooth_clock.c
+++ b/firmware/bluetooth_rxtx/ubertooth_clock.c
@@ -32,6 +32,12 @@ void clkn_stop()
 
 	clkn_offset = 0;
 	clk100ns_offset = 0;
+
+	clk_drift_ppm = 0;
+	clk_drift_correction = 0;
+
+	clkn_last_drift_fix = 0;
+	clkn_next_drift_fix = 0;
 }
 
 void clkn_start()

--- a/firmware/bluetooth_rxtx/ubertooth_clock.h
+++ b/firmware/bluetooth_rxtx/ubertooth_clock.h
@@ -38,6 +38,13 @@ volatile uint32_t last_hop;
 volatile uint32_t clkn_offset;
 volatile uint16_t clk100ns_offset;
 
+// linear clock drift
+volatile int16_t clk_drift_ppm;
+volatile uint16_t clk_drift_correction;
+
+volatile uint32_t clkn_last_drift_fix;
+volatile uint32_t clkn_next_drift_fix;
+
 #define CLK100NS (3125*(clkn & 0xfffff) + T0TC)
 #define LE_BASECLK (12500)                    // 1.25 ms in units of 100ns
 

--- a/host/libubertooth/src/ubertooth_control.c
+++ b/host/libubertooth/src/ubertooth_control.c
@@ -72,6 +72,16 @@ void cmd_trim_clock(struct libusb_device_handle* devh, uint16_t offset)
 	ubertooth_cmd_async(devh, CTRL_OUT, UBERTOOTH_TRIM_CLOCK, data, 2);
 }
 
+void cmd_fix_clock_drift(struct libusb_device_handle* devh, int16_t ppm)
+{
+	uint8_t data[2] = {
+		(ppm >> 8) & 0xff,
+		(ppm >> 0) & 0xff
+	};
+
+	ubertooth_cmd_async(devh, CTRL_OUT, UBERTOOTH_FIX_CLOCK_DRIFT, data, 2);
+}
+
 int cmd_ping(struct libusb_device_handle* devh)
 {
 	int r;

--- a/host/libubertooth/src/ubertooth_control.h
+++ b/host/libubertooth/src/ubertooth_control.h
@@ -87,6 +87,7 @@ int ubertooth_cmd_async(struct libusb_device_handle* devh,
 	                    uint16_t size);
 
 void cmd_trim_clock(struct libusb_device_handle* devh, uint16_t offset);
+void cmd_fix_clock_drift(struct libusb_device_handle* devh, int16_t ppm);
 int cmd_ping(struct libusb_device_handle* devh);
 int cmd_rx_syms(struct libusb_device_handle* devh);
 int cmd_tx_syms(struct libusb_device_handle* devh);

--- a/host/libubertooth/src/ubertooth_interface.h
+++ b/host/libubertooth/src/ubertooth_interface.h
@@ -25,7 +25,7 @@
 #include <stdint.h>
 
 // increment on every API change
-#define UBERTOOTH_API_VERSION 0
+#define UBERTOOTH_API_VERSION 1
 
 #define DMA_SIZE 50
 

--- a/host/libubertooth/src/ubertooth_interface.h
+++ b/host/libubertooth/src/ubertooth_interface.h
@@ -109,6 +109,7 @@ enum ubertooth_usb_commands {
 	UBERTOOTH_READ_ALL_REGISTERS = 66,
 	UBERTOOTH_RX_GENERIC         = 67,
 	UBERTOOTH_TX_GENERIC_PACKET  = 68,
+	UBERTOOTH_FIX_CLOCK_DRIFT    = 69,
 };
 
 enum jam_modes {


### PR DESCRIPTION
This is related to #214. I have successfully tested the patch with different Ubertooth sticks whose clocks drifted in different directions.