### PR TITLE
fix bootloader error messages in ubertooth-dfu + some firmware bugs and compiler warnings

### DIFF
--- a/firmware/bluetooth_rxtx/bluetooth.c
+++ b/firmware/bluetooth_rxtx/bluetooth.c
@@ -73,10 +73,11 @@ void precalc(void)
 		for(i = 0; i < 10; i++)
 			used_channels += count_bits((uint64_t) afh_map[i]);
 		j = 0;
-		for (i = 0; i < NUM_BREDR_CHANNELS; i++)
+		for (i = 0; i < NUM_BREDR_CHANNELS; i++) {
 			chan = (i * 2) % NUM_BREDR_CHANNELS;
 			if(afh_map[chan/8] & (0x1 << (chan % 8)))
 				bank[j++] = chan;
+		}
 	}
 }
 

--- a/firmware/bluetooth_rxtx/bluetooth_rxtx.c
+++ b/firmware/bluetooth_rxtx/bluetooth_rxtx.c
@@ -1362,7 +1362,7 @@ void br_transmit()
 {
 	uint16_t gio_save;
 
-	uint32_t clkn_saved;
+	uint32_t clkn_saved = 0;
 
 	uint16_t preamble = (target.syncword & 1) == 1 ? 0x5555 : 0xaaaa;
 	uint8_t trailer = ((target.syncword >> 63) & 1) == 1 ? 0xaa : 0x55;

--- a/firmware/bluetooth_rxtx/bluetooth_rxtx.c
+++ b/firmware/bluetooth_rxtx/bluetooth_rxtx.c
@@ -379,7 +379,7 @@ static int vendor_request_handler(uint8_t request, uint16_t* request_params, uin
 
 	case UBERTOOTH_FLASH:
 		bootloader_ctrl = DFU_MODE;
-		reset();
+		requested_mode = MODE_RESET;
 		break;
 
 	case UBERTOOTH_SPECAN:

--- a/firmware/bluetooth_rxtx/cc2400_rangetest.c
+++ b/firmware/bluetooth_rxtx/cc2400_rangetest.c
@@ -222,8 +222,8 @@ void cc2400_repeater(volatile u16 *chan_ptr)
 			for (i = 0; i < 16; i++) {
 				buf[21] = i;
 				while ((cc2400_get(FSMSTATE) & 0x1f) != STATE_STROBE_FS_ON);
-					for (j = 0; j < len; j++)
-						cc2400_set8(FIFOREG, buf[j]);
+				for (j = 0; j < len; j++)
+					cc2400_set8(FIFOREG, buf[j]);
 				cc2400_strobe(STX);
 			}
 		}
@@ -250,7 +250,7 @@ void cc2400_txtest(volatile u8 *mod_ptr, volatile u16 *chan_ptr)
 	cc2400_set(MDMTST0, 0x334b); // with PRNG
 	cc2400_set(GRMDM,   0x0df1); // default value
 	cc2400_set(FSDIV,   *chan_ptr);
-	cc2400_set(MDMCTRL, mdmctrl); 
+	cc2400_set(MDMCTRL, mdmctrl);
 
 	while (!(cc2400_status() & XOSC16M_STABLE));
 	cc2400_strobe(SFSON);

--- a/firmware/bootloader/Makefile
+++ b/firmware/bootloader/Makefile
@@ -93,17 +93,17 @@ CPPSRC = $(TARGET).cpp \
 #     Even though the DOS/Win* filesystem matches both .s and .S the same,
 #     it will preserve the spelling of the filenames, and gcc itself does
 #     care about how the name is spelled on its command-line.
-ASRC = 
+ASRC =
 
 # Object files directory
 #     To put object files in current directory, use a dot (.), do NOT make
 #     this an empty or blank macro!
 OBJDIR = .
 
-# Optimization level, can be [0, 1, 2, 3, s]. 
+# Optimization level, can be [0, 1, 2, 3, s].
 #     0 = turn off optimization. s = optimize for size.
 #     (Note: 3 is not always the best optimization level. See libc FAQ.)
-OPT = 0
+OPT = s
 
 # Debugging format.
 DEBUG = dwarf-2 -g3
@@ -125,10 +125,10 @@ EXTRAINCDIRS = $(LIBS_PATH) $(LPCUSB_PATH) ../../host/libubertooth/src
 CSTANDARD = -std=gnu99
 
 # Place -D or -U options here for C sources
-CDEFS  = -D$(BOARD) -D$(LPCUSB_TARGET) $(COMPILE_OPTS)
+CDEFS  = -D$(BOARD) -D$(LPCUSB_TARGET) $(COMPILE_OPTS) -Wa,-a,-ad
 
 # Place -D or -U options here for ASM sources
-ADEFS = 
+ADEFS =
 
 # Place -D or -U options here for C++ sources
 CPPDEFS = -D$(BOARD) -D$(LPCUSB_TARGET) $(COMPILE_OPTS)
@@ -150,13 +150,13 @@ CFLAGS += -fmessage-length=0
 CFLAGS += -fno-builtin
 CFLAGS += -ffunction-sections
 CFLAGS += -Wextra
-CFLAGS += -D__thumb2__=1 
-CFLAGS += -msoft-float 
-CFLAGS += -mno-sched-prolog 
-CFLAGS += -fno-hosted 
-CFLAGS += -mtune=cortex-m3 
-CFLAGS += -march=armv7-m 
-CFLAGS += -mfix-cortex-m3-ldrd  
+CFLAGS += -D__thumb2__=1
+CFLAGS += -msoft-float
+CFLAGS += -mno-sched-prolog
+CFLAGS += -fno-hosted
+CFLAGS += -mtune=cortex-m3
+CFLAGS += -march=armv7-m
+CFLAGS += -mfix-cortex-m3-ldrd
 #CFLAGS += -Wundef
 #CFLAGS += -funsigned-char
 #CFLAGS += -funsigned-bitfields
@@ -205,7 +205,7 @@ CPPFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS))
 #  -Wa,...:   tell GCC to pass this to the assembler.
 #  -alhms:   create listing
 #  -gstabs:   have the assembler create line number information
-#  -listing-cont-lines: Sets the maximum number of continuation lines of hex 
+#  -listing-cont-lines: Sets the maximum number of continuation lines of hex
 #       dump that will be displayed for a given single line of source input.
 ASFLAGS = -g$(DEBUG) $(ADEFS) -I.  -alhms=$(<:%.S=$(OBJDIR)/%.lst)
 
@@ -222,15 +222,15 @@ EXTRALIBDIRS = $(LIBS_PATH)
 #    -Map:      create map file
 #    --cref:    add cross reference to  map file
 LDFLAGS = -Wl,-Map=$(TARGET).map
-#LDFLAGS += -Wl,--relax 
+#LDFLAGS += -Wl,--relax
 #LDFLAGS += --gc-sections
 LDFLAGS += $(patsubst %,-L%,$(EXTRALIBDIRS))
 LDFLAGS += -static
-LDFLAGS += -Wl,--start-group 
+LDFLAGS += -Wl,--start-group
 #LDFLAGS += -L$(THUMB2GNULIB) -L$(THUMB2GNULIB2)
-LDFLAGS += -lc -lg -lstdc++ -lsupc++ 
-LDFLAGS += -lgcc -lm 
-LDFLAGS += -Wl,--end-group 
+LDFLAGS += -lc -lg -lstdc++ -lsupc++
+LDFLAGS += -lgcc -lm
+LDFLAGS += -Wl,--end-group
 
 #---------------- Programming Options ----------------
 LPCISP  ?= $(shell which lpc21isp)
@@ -255,7 +255,7 @@ REMOVE = rm -f
 # English
 MSG_BEGIN = -------- begin --------
 MSG_END = --------  end  --------
-MSG_SIZE_BEFORE = Size before: 
+MSG_SIZE_BEFORE = Size before:
 MSG_SIZE_AFTER = Size after:
 MSG_FLASH = Creating load file for Flash:
 MSG_EEPROM = Creating load file for EEPROM:
@@ -269,10 +269,10 @@ MSG_CLEANING = Cleaning project:
 MSG_CREATING_LIBRARY = Creating library:
 
 # Define all object files.
-OBJ = $(SRC:%.c=$(OBJDIR)/%.o) $(CPPSRC:%.cpp=$(OBJDIR)/%.o) $(ASRC:%.S=$(OBJDIR)/%.o) 
+OBJ = $(SRC:%.c=$(OBJDIR)/%.o) $(CPPSRC:%.cpp=$(OBJDIR)/%.o) $(ASRC:%.S=$(OBJDIR)/%.o)
 
 # Define all listing files.
-LST = $(SRC:%.c=$(OBJDIR)/%.lst) $(CPPSRC:%.cpp=$(OBJDIR)/%.lst) $(ASRC:%.S=$(OBJDIR)/%.lst) 
+LST = $(SRC:%.c=$(OBJDIR)/%.lst) $(CPPSRC:%.cpp=$(OBJDIR)/%.lst) $(ASRC:%.S=$(OBJDIR)/%.lst)
 
 # Compiler flags to generate dependency files.
 GENDEPFLAGS = -MMD -MP -MD
@@ -328,9 +328,9 @@ showtarget:
 	@echo ARM Model: $(CPU)
 	@echo Board:     $(BOARD)
 	@echo --------------------------------------
-	
+
 # Display compiler version information.
-gccversion: 
+gccversion:
 	@$(CC) --version
 
 program: $(TARGET).hex
@@ -390,13 +390,13 @@ program: $(TARGET).hex
 $(OBJDIR)/%.o : %.c
 	@echo
 	@echo $(MSG_COMPILING) $<
-	$(CC) -c $(ALL_CFLAGS) $< -o $@ 
+	$(CC) -c $(ALL_CFLAGS) $< -o $@
 
 # Compile: create object files from C++ source files.
 $(OBJDIR)/%.o : %.cpp
 	@echo
 	@echo $(MSG_COMPILING_CPP) $<
-	$(CC) -c $(ALL_CPPFLAGS) $< -o $@ 
+	$(CC) -c $(ALL_CPPFLAGS) $< -o $@
 
 # Compile: create assembler files from C source files.
 %.s : %.c
@@ -414,14 +414,14 @@ $(OBJDIR)/%.o : %.S
 
 # Create preprocessed source for use in sending a bug report.
 %.i : %.c
-	$(CC) -E -mmcu=$(CPU) -I. $(CFLAGS) $< -o $@ 
+	$(CC) -E -mmcu=$(CPU) -I. $(CFLAGS) $< -o $@
 
 # Target: clean project.
 clean: begin clean_list clean_binary end
 
 clean_binary:
 	$(REMOVE) $(TARGET).hex
-	
+
 clean_list:
 	@echo $(MSG_CLEANING)
 	$(REMOVE) $(TARGET).eep

--- a/firmware/bootloader/bootloader.cpp
+++ b/firmware/bootloader/bootloader.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
-	LPCUSB, an USB device driver for LPC microcontrollers	
+	LPCUSB, an USB device driver for LPC microcontrollers
 	Copyright (C) 2006 Bertrik Sikken (bertrik@sikken.nl)
 
 	Redistribution and use in source and binary forms, with or without
@@ -37,7 +37,7 @@
 	THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
 	IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
 	OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-	IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, 
+	IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
 	INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
 	NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
 	DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
@@ -56,7 +56,7 @@ extern "C" {
 
 #include "dfu.h"
 
-#define TIMEOUT 1572864
+#define DFU_TIMEOUT 1572864
 
 #define MAX_PACKET_SIZE	64
 
@@ -95,12 +95,12 @@ extern "C" {
 #define ID_PRODUCT 0x0004
 #endif
 
-static const u8 dfu_descriptors[] = {
+static uint8_t dfu_descriptors[] = {
 
 /* Device descriptor */
-	0x12,              		
-	DESC_DEVICE,       		
-	LE_WORD(0x0200),		// bcdUSB	
+	0x12,
+	DESC_DEVICE,
+	LE_WORD(0x0200),		// bcdUSB
 	0x00,              		// bDeviceClass
 	0x00,              		// bDeviceSubClass
 	0x00,              		// bDeviceProtocol
@@ -124,8 +124,8 @@ static const u8 dfu_descriptors[] = {
 	0x32,  				// bMaxPower
 
 // interface
-	0x09,   				
-	DESC_INTERFACE, 
+	0x09,
+	DESC_INTERFACE,
 	0x00,  		 		// bInterfaceNumber
 	0x00,   			// bAlternateSetting
 	0x00,   			// bNumEndPoints
@@ -137,9 +137,9 @@ static const u8 dfu_descriptors[] = {
 // DFU Functional Descriptor
 	0x09,
 	DESC_DFU_FUNCTIONAL,
-	DFU::WILL_DETACH | DFU::MANIFESTATION_TOLERANT | DFU::CAN_UPLOAD | DFU::CAN_DNLOAD,		// bmAttributes 
-	LE_WORD(DFU::detach_timeout_ms),// wDetachTimeOut 
-	LE_WORD(DFU::transfer_size),	// wTransferSize 
+	DFU::WILL_DETACH | DFU::MANIFESTATION_TOLERANT | DFU::CAN_UPLOAD | DFU::CAN_DNLOAD,		// bmAttributes
+	LE_WORD(DFU::detach_timeout_ms),// wDetachTimeOut
+	LE_WORD(DFU::transfer_size),	// wTransferSize
 	LE_WORD(0x0101),		// bcdDFUVersion
 
 // string descriptors
@@ -181,7 +181,7 @@ int bootloader_usb_init()
 {
 	// initialise stack
 	USBInit();
-	
+
 	// register device descriptors
 	USBRegisterDescriptors(dfu_descriptors);
 
@@ -190,7 +190,7 @@ int bootloader_usb_init()
 
 	// enable USB interrupts
 	//ISER0 |= ISER0_ISE_USB;
-	
+
 	// connect to bus
 	USBHwConnect(TRUE);
 
@@ -259,7 +259,7 @@ static void run_bootloader()
 	while( dfu.in_dfu_mode() ) {
 		USBHwISR();
 		update_leds();
-		if (use_timeout && dfu.dfu_virgin() && (count > TIMEOUT))
+		if (use_timeout && dfu.dfu_virgin() && (count > DFU_TIMEOUT))
 			break;
 	}
 

--- a/firmware/bootloader/bootloader.cpp
+++ b/firmware/bootloader/bootloader.cpp
@@ -286,14 +286,18 @@ int main(void)
 		if (bootloader_ctrl == DFU_MODE) {
 			ubertooth_init();
 			run_bootloader();
+			bootloader_ctrl = 0;
+			wait(1);
+			reset();
 		} else if (ENTRY_PIN) {
 			use_timeout = true;
 			ubertooth_init();
 			run_bootloader();
+			wait(1);
+			reset();
 		}
 	}
 
-	bootloader_ctrl = 0;
 	run_application();
 
 	return 0;

--- a/firmware/common/LPC17xx_Startup.c
+++ b/firmware/common/LPC17xx_Startup.c
@@ -60,7 +60,7 @@ extern int main(void);
 /* Reset Handler */
 void Reset_Handler(void)
 {
-    unsigned long *src, *dest;
+	unsigned long *src, *dest;
 
 	// Copy the data segment initializers from flash to SRAM
 	src = &_etext;
@@ -76,11 +76,11 @@ void Reset_Handler(void)
 		*src++ = 0;
 	}
 
-    __libc_init_array();
-    
-    // Set the vector table location.
-    SCB_VTOR = &_interrupt_vector_table;
-    
+	__libc_init_array();
+
+	// Set the vector table location.
+	SCB_VTOR = (uint32_t)&_interrupt_vector_table;
+
 	main();
 
 	// In case main() fails, have something to breakpoint

--- a/host/libubertooth/src/ubertooth_control.c
+++ b/host/libubertooth/src/ubertooth_control.c
@@ -431,9 +431,8 @@ int cmd_flash(struct libusb_device_handle* devh)
 
 	r = libusb_control_transfer(devh, CTRL_OUT, UBERTOOTH_FLASH, 0, 0,
 			NULL, 0, 1000);
-	/* LIBUSB_ERROR_PIPE or LIBUSB_ERROR_OTHER is expected */
-	if ((r != LIBUSB_ERROR_PIPE) && (r != LIBUSB_ERROR_OTHER)) {
-	    show_libusb_error(r);
+	if (r != LIBUSB_SUCCESS) {
+		show_libusb_error(r);
 		return r;
 	}
 	return 0;


### PR DESCRIPTION
This patch fixes the following bugs:

* When entering the dfu mode, the Ubertooth performs a reset inside of the USB interrupt. Thus the control transfer never completes which leads to a libusb error message. This bug is fixed by not resetting the Ubertooth in the interrupt but only setting requested_mode to MODE_RESET which will cause a reset in the main loop
* Sometimes after flashing a new firmware and detatching the Ubertooth, its firmware does not start reliably and thus the host can't detect the stick before it is power cycled. This was fixed by performing a reset after detatching the Ubertooth.
* Some braces in a for loop were missing which would cause the Ubertooth to use an incorrect hopping pattern when following a piconet in AFH mode.
* Some compiler warnings that probably didn't cause bigger problems

I think there won't be many users who will flash a new bootloader to their device. But since I often need to flash a new firmware to the stick, I benefit a lot from a more reliable dfu mode and would like to share my patches.