### PR TITLE
rssi: calculate signal and noise in firmware

### DIFF
--- a/firmware/bluetooth_rxtx/bluetooth_rxtx.c
+++ b/firmware/bluetooth_rxtx/bluetooth_rxtx.c
@@ -68,7 +68,7 @@ volatile uint8_t modulation = MOD_BT_BASIC_RATE;
 /* specan stuff */
 volatile uint16_t low_freq = 2400;
 volatile uint16_t high_freq = 2483;
-volatile int8_t rssi_threshold = -30;  // -54dBm - 30 = -84dBm
+volatile int8_t rssi_threshold = -84;
 
 /* Generic TX stuff */
 generic_tx_packet tx_pkt;
@@ -140,10 +140,12 @@ static int enqueue(uint8_t type, uint8_t* buf)
 		f->clkn_high = idle_buf_clkn_high;
 		f->clk100ns = idle_buf_clk100ns;
 		f->channel = (uint8_t)((idle_buf_channel - 2402) & 0xff);
-		f->rssi_min = rssi_min;
-		f->rssi_max = rssi_max;
-		f->rssi_avg = rssi_get_avg(idle_buf_channel);
-		f->rssi_count = rssi_count;
+		f->rssi_min = rssi_get_min();
+		f->rssi_max = rssi_get_max();
+		f->rssi_noise = rssi_get_noise();
+		f->rssi_signal = rssi_get_signal();
+		f->rssi_avg = rssi_get_avg();
+		f->rssi_count = rssi_get_cnt();
 	}
 
 	memcpy(f->data, buf, DMA_SIZE);
@@ -400,7 +402,7 @@ static int vendor_request_handler(uint8_t request, uint16_t* request_params, uin
 	case UBERTOOTH_LED_SPECAN:
 		if (request_params[0] > 256)
 			return 0;
-		rssi_threshold = 54 - request_params[0];
+		rssi_threshold = request_params[0];
 		requested_mode = MODE_LED_SPECAN;
 		*data_len = 0;
 		break;
@@ -1270,12 +1272,11 @@ void bt_stream_rx()
 		 * at multiple trigger points there. The MAX() below
 		 * helps with statistics in the case that cs_trigger
 		 * happened before the loop started. */
-		rssi_reset();
 		rssi_at_trigger = INT8_MIN;
 		while (!rx_tc) {
-			rssi = (int8_t)(cc2400_get(RSSI) >> 8);
+			rssi = cc2400_rssi();
 			if (cs_trigger && (rssi_at_trigger == INT8_MIN)) {
-				rssi = MAX(rssi,(cs_threshold_cur+54));
+				rssi = MAX(rssi, cs_threshold_cur);
 				rssi_at_trigger = rssi;
 			}
 			rssi_add(rssi);
@@ -1284,6 +1285,7 @@ void bt_stream_rx()
 
 			/* If timer says time to hop, do it. */
 			if (do_hop) {
+				rssi_reset();
 				hop();
 			} else {
 				TXLED_CLR;
@@ -1307,8 +1309,6 @@ void bt_stream_rx()
 			dma_discard = 0;
 		}
 
-		rssi_iir_update(channel);
-
 		/* Set squelch hold if there was either a CS trigger, squelch
 		 * is disabled, or if the current rssi_max is above the same
 		 * threshold. Currently, this is redundant, but allows for
@@ -1318,11 +1318,13 @@ void bt_stream_rx()
 			cs_trigger = 0;
 		}
 
-		if (rssi_max >= (cs_threshold_cur + 54)) {
+		if (rssi_get_max() >= cs_threshold_cur) {
 			status |= RSSI_TRIGGER;
 		}
 
 		enqueue(BR_PACKET, (uint8_t*)idle_rxbuf);
+
+		rssi_reset();
 
 		handle_usb(clkn);
 		rx_tc = 0;
@@ -1548,9 +1550,9 @@ void bt_generic_le(u8 active_mode)
 		rssi_at_trigger = INT8_MIN;
 		while ((rx_tc == 0) && (rx_err == 0))
 		{
-			rssi = (int8_t)(cc2400_get(RSSI) >> 8);
+			rssi = cc2400_rssi();
 			if (cs_trigger && (rssi_at_trigger == INT8_MIN)) {
-				rssi = MAX(rssi,(cs_threshold_cur+54));
+				rssi = MAX(rssi,cs_threshold_cur);
 				rssi_at_trigger = rssi;
 			}
 			rssi_add(rssi);
@@ -1568,8 +1570,6 @@ void bt_generic_le(u8 active_mode)
 		if (rx_tc > 1)
 			status |= DMA_OVERFLOW;
 
-		rssi_iir_update(channel);
-
 		/* Set squelch hold if there was either a CS trigger, squelch
 		 * is disabled, or if the current rssi_max is above the same
 		 * threshold. Currently, this is redundant, but allows for
@@ -1580,7 +1580,7 @@ void bt_generic_le(u8 active_mode)
 			cs_trigger = 0;
 		}
 
-		if (rssi_max >= (cs_threshold_cur + 54)) {
+		if (rssi_get_max(channel) >= cs_threshold_cur) {
 			status |= RSSI_TRIGGER;
 			hold = CS_HOLD_TIME;
 		}
@@ -1670,8 +1670,8 @@ void bt_le_sync(u8 active_mode)
 		while ((rx_tc == 0) && (rx_err == 0) && (do_hop == 0) && requested_mode == active_mode)
 			;
 
-		rssi = (int8_t)(cc2400_get(RSSI) >> 8);
-		rssi_min = rssi_max = rssi;
+		rssi = cc2400_rssi();
+		rssi_add(rssi);
 
 		if (requested_mode != active_mode) {
 			goto cleanup;
@@ -1746,6 +1746,8 @@ void bt_le_sync(u8 active_mode)
 		packet_cb((uint8_t *)packet);
 		enqueue(LE_PACKET, (uint8_t *)packet);
 		le.last_packet = CLK100NS;
+
+		rssi_reset();
 
 	rx_flush:
 		// this might happen twice, but it's safe to do so
@@ -2438,7 +2440,7 @@ void specan()
 			volatile u32 j = 500; while (--j); //FIXME crude delay
 			buf[3 * i] = (f >> 8) & 0xFF;
 			buf[(3 * i) + 1] = f  & 0xFF;
-			buf[(3 * i) + 2] = cc2400_get(RSSI) >> 8;
+			buf[(3 * i) + 2] = cc2400_rssi();
 			i++;
 			if (i == 16) {
 				enqueue(SPECAN, buf);
@@ -2484,7 +2486,7 @@ void led_specan()
 
 		/* give the CC2400 time to acquire RSSI reading */
 		volatile u32 j = 500; while (--j); //FIXME crude delay
-		lvl = (int8_t)((cc2400_get(RSSI) >> 8) & 0xff);
+		lvl = cc2400_rssi();
 		if (lvl > rssi_threshold) {
 			switch (i) {
 				case 0:

--- a/firmware/bluetooth_rxtx/ubertooth_rssi.h
+++ b/firmware/bluetooth_rxtx/ubertooth_rssi.h
@@ -24,13 +24,13 @@
 
 #include "inttypes.h"
 
-int8_t rssi_max;
-int8_t rssi_min;
-uint8_t rssi_count;
-
-void rssi_reset(void);
+void rssi_reset();
 void rssi_add(int8_t v);
-void rssi_iir_update(uint16_t channel);
-int8_t rssi_get_avg(uint16_t channel);
+int8_t rssi_get_avg();
+int8_t rssi_get_signal();
+int8_t rssi_get_noise();
+int8_t rssi_get_min();
+int8_t rssi_get_max();
+uint8_t rssi_get_cnt();
 
 #endif

--- a/firmware/common/ubertooth.c
+++ b/firmware/common/ubertooth.c
@@ -64,7 +64,7 @@ void wait_us(u32 us)
  */
 void gpio_init()
 {
-	/* 
+	/*
 	 * Set all pins for GPIO.  This shouldn't be necessary after a reset, but
 	 * we might get called at other times.
 	 */
@@ -306,6 +306,11 @@ u16 cc2400_get(u8 reg)
 	return in & 0xFFFF;
 }
 
+int8_t cc2400_rssi()
+{
+	return (int8_t)(cc2400_get(RSSI) >> 8) - 54;
+}
+
 /* write 16 bit value to a register */
 void cc2400_set(u8 reg, u16 val)
 {
@@ -374,7 +379,7 @@ void cc2400_fifo_write(u8 len, u8 *data) {
 		SCLK_SET;
 		SCLK_CLR;
 	}
-	
+
 	spi_delay();
 	/* end transaction by raising CSN */
 	CSN_SET;
@@ -531,9 +536,9 @@ void reset()
 	USRLED_CLR;
 	WDMOD |= WDMOD_WDEN | WDMOD_WDRESET;
 	WDFEED_SEQUENCE;
-	
+
 	/* Set watchdog timeout to 256us (minimum) */
-	
+
 	/* sleep for 1s (minimum) */
 	wait(1);
 }
@@ -633,7 +638,7 @@ void get_part_num(uint8_t *buffer, int *len)
 	buffer[3] = (result[1] >> 16) & 0xFF;
 	buffer[4] = (result[1] >> 24) & 0xFF;
 	*len = 5;
-	
+
 }
 
 void get_device_serial(uint8_t *buffer, int *len)

--- a/firmware/common/ubertooth.h
+++ b/firmware/common/ubertooth.h
@@ -323,6 +323,7 @@ void atest_init(void);
 void cc2400_init(void);
 u32 cc2400_spi(u8 len, u32 data);
 u16 cc2400_get(u8 reg);
+int8_t cc2400_rssi();
 void cc2400_set(u8 reg, u16 val);
 u8 cc2400_get8(u8 reg);
 void cc2400_set8(u8 reg, u8 val);

--- a/host/libubertooth/src/ubertooth_callback.c
+++ b/host/libubertooth/src/ubertooth_callback.c
@@ -345,7 +345,7 @@ void cb_btle(ubertooth_t* ut, void* args)
 	prev_ts = rx->clk100ns;
 	printf("systime=%u freq=%d addr=%08x delta_t=%.03f ms rssi=%d\n",
 	       systime, rx->channel + 2402, lell_get_access_address(pkt),
-	       ts_diff / 10000.0, rx->rssi_min);
+	       ts_diff / 10000.0, rx->rssi_signal);
 
 	int len = (rx->data[5] & 0x3f) + 6 + 3;
 	if (len > 50) len = 50;

--- a/host/libubertooth/src/ubertooth_interface.h
+++ b/host/libubertooth/src/ubertooth_interface.h
@@ -25,7 +25,7 @@
 #include <stdint.h>
 
 // increment on every API change
-#define UBERTOOTH_API_VERSION 1
+#define UBERTOOTH_API_VERSION 2
 
 #define DMA_SIZE 50
 
@@ -157,17 +157,18 @@ enum usb_pkt_status {
  * USB packet for Bluetooth RX (64 total bytes)
  */
 typedef struct {
-	u8     pkt_type;
-	u8     status;
-	u8     channel;
-	u8     clkn_high;
-	u32    clk100ns;
-	char   rssi_max;   // Max RSSI seen while collecting symbols in this packet
-	char   rssi_min;   // Min ...
-	char   rssi_avg;   // Average ...
-	u8     rssi_count; // Number of ... (0 means RSSI stats are invalid)
-	u8     reserved[2];
-	u8     data[DMA_SIZE];
+	uint8_t  pkt_type;
+	uint8_t  status;
+	uint8_t  channel;
+	uint8_t  clkn_high;
+	uint32_t clk100ns;
+	int8_t   rssi_max;   // Max RSSI seen while collecting symbols in this packet
+	int8_t   rssi_min;   // Min ...
+	int8_t   rssi_avg;   // Average ...
+	uint8_t  rssi_count; // Number of ... (0 means RSSI stats are invalid)
+	int8_t   rssi_signal;
+	int8_t   rssi_noise;
+	uint8_t  data[DMA_SIZE];
 } usb_pkt_rx;
 
 typedef struct {

--- a/host/python/specan_ui/specan/Ubertooth.py
+++ b/host/python/specan_ui/specan/Ubertooth.py
@@ -46,9 +46,8 @@ class Ubertooth(object):
         self.proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         default_raw_rssi = -128
-        rssi_offset = -54
         rssi_values = numpy.empty((bin_count,), dtype=numpy.float32)
-        rssi_values.fill(default_raw_rssi + rssi_offset)
+        rssi_values.fill(default_raw_rssi)
 
         # Give it a chance to time out if it fails to find Ubertooth
         time.sleep(0.5)
@@ -69,8 +68,8 @@ class Ubertooth(object):
 
                         # We started a new frame, send the existing frame
                         yield (frequency_axis, rssi_values)
-                        rssi_values.fill(default_raw_rssi + rssi_offset)
-                    rssi_values[index] = raw_rssi_value + rssi_offset
+                        rssi_values.fill(default_raw_rssi)
+                    rssi_values[index] = raw_rssi_value
 
     def close(self):
         if self.proc and not self.proc.poll():


### PR DESCRIPTION
Since the RSSI and SNR calculations sometimes deliver unreliable values, I would like to propose a new RSSI and SNR algorithm.

Until now, the firmware calculated the RSSI value as an exponential moving average. Since it has a low pass behaviour, it generates values with a strong bias to its initial value of 0 (-54 dBm). It was replaced by a fixed average over up to 40 RSSI values (typically 35 - 38 RSSI values are acquired while waiting for the DMA to fill).

Before an USB packet is transmitted, the signal and noise values are calculated:

1. calculate the average between the minimal and the maximal RSSI value
2. each of the 40 RSSI values below that value are considered noise values, each of the 40 RSSI values above that value are considered signal values
3. calculate the average of all signal values
4. calculate the average of all noise values
5. add min, max, avg, count, signal and noise values to the package header

For now I use the two reserved bytes in the USB packet header for transmitting the signal and noise values to the host.

RSSI values are stored as raw dBm values without the 54 dB offset of the CC2400 radio chip.

I have also made cb_btle() print the signal rssi value of a packet instead of its minimal rssi value, which I think was one topic of #128 .

I am a little worried about using the reserved bytes in the USB packet header. So please feel free to discuss my changes.