### PR TITLE
host: Fix unreachable libusb_free_device_list() in ubertooth_count()

### DIFF
--- a/host/libubertooth/src/ubertooth.c
+++ b/host/libubertooth/src/ubertooth.c
@@ -127,8 +127,8 @@ unsigned ubertooth_count(void) {
 		}
 	}
 
-	return uberteeth;
 	libusb_free_device_list(usb_list,1);
+	return uberteeth;
 }
 
 static struct libusb_device_handle* find_ubertooth_device(int ubertooth_device)


### PR DESCRIPTION
The `ubertooth_count()` function added in c920e95c1cc8a8e701cfeff5c311721e140bc888 frees the device list after the `return`.