### PR TITLE
le: Fixed CC2400 FIFO usage to allow BLE packets that are larger then 32 bytes

### DIFF
--- a/host/libubertooth/src/ubertooth_interface.h
+++ b/host/libubertooth/src/ubertooth_interface.h
@@ -114,9 +114,8 @@ enum ubertooth_usb_commands {
 	UBERTOOTH_LE_SET_ADV_DATA    = 71,
 };
 
-// maximum adv data len: 32 - (2 + 6 + 3)
-#define LE_ADV_MAX_LEN 21
-
+// maximum adv data by the 5.0 specs 
+#define LE_ADV_MAX_LEN 255
 enum jam_modes {
 	JAM_NONE       = 0,
 	JAM_ONCE       = 1,


### PR DESCRIPTION
Added some code to correctly fill-out the CC2400 FIFO while transmitting BLE and removed the size limitation that was placed as a workaround.
This modified code was used in the BLEEDINGBIT presentation at BHEU18.