### PR TITLE
Use `DLT_BLUETOOTH_LE_LL` for PPI rather than `DLT_USER0`.

### DIFF
--- a/host/python/extcap/btle-extcap.py
+++ b/host/python/extcap/btle-extcap.py
@@ -117,7 +117,8 @@ def list_interfaces():
 
 
 def list_dlts():
-    print("dlt {number=147}{name=USER0}{display=Bluetooth Low Energy}")
+    # -c emits DLT_PPI + DLT_BLUETOOTH_LE_LL
+    print("dlt {number=192}{name=PPI}{display=Bluetooth Low Energy}")
 
 
 def config():

--- a/host/ubertooth-tools/src/ubertooth-btle.c
+++ b/host/ubertooth-tools/src/ubertooth-btle.c
@@ -130,7 +130,7 @@ static void usage(void)
 	printf("    Misc:\n");
 	printf("\t-r<filename> capture packets to PCAPNG file\n");
 	printf("\t-q<filename> capture packets to PCAP file (DLT_BLUETOOTH_LE_LL_WITH_PHDR)\n");
-	printf("\t-c<filename> capture packets to PCAP file (DLT_PPI)\n");
+	printf("\t-c<filename> capture packets to PCAP file (DLT_PPI + DLT_BLUETOOTH_LE_LL)\n");
 	printf("\t-A<index> advertising channel index (default 37)\n");
 	printf("\t-v[01] verify CRC mode, get status or enable/disable\n");
 	printf("\t-x<n> allow n access address offenses (default 32)\n");


### PR DESCRIPTION
`DLT_USER*` is intended for private use.  It requires extra configuration in tools like Wireshark to make it actually work, and causes problems for Ubertooth users in other tools (eg: secdev/scapy#1673)

I don't have the hardware for this, so I cannot test this change.

Companion `libbtbb` PR: https://github.com/greatscottgadgets/libbtbb/pull/55