### PR TITLE
extern packet_counter_max to compile with gcc-10

### DIFF
--- a/host/libubertooth/src/ubertooth_callback.c
+++ b/host/libubertooth/src/ubertooth_callback.c
@@ -27,7 +27,7 @@
 
 #include "ubertooth_callback.h"
 
-unsigned int packet_counter_max;
+extern unsigned int packet_counter_max;
 
 static int8_t cc2400_rssi_to_dbm( const int8_t rssi )
 {


### PR DESCRIPTION
Fixes: https://github.com/greatscottgadgets/ubertooth/issues/408