### PR TITLE
Add attribute unused in ubertooth-ego to fix CI

### DIFF
--- a/host/ubertooth-tools/src/ubertooth-ego.c
+++ b/host/ubertooth-tools/src/ubertooth-ego.c
@@ -32,7 +32,7 @@
 ubertooth_t* ut = NULL;
 int running = 1;
 
-void quit(int signo)
+void quit(int signo __attribute__((unused)))
 {
 	running = 0;
 }


### PR DESCRIPTION
Travic build seems to fail due to an unused parameter in ubertooth-ego.c
This patch should correct it.