### PR TITLE
simplify ubertooth-dfu variable in firmware build

### DIFF
--- a/firmware/common.mk
+++ b/firmware/common.mk
@@ -261,7 +261,7 @@ NM = $(CROSS_COMPILE)nm
 REMOVE = rm -f
 
 # DFU tool should be ubertooth-dfu
-DFU_TOOL ?= $(strip $(shell which ubertooth-dfu))
+DFU_TOOL ?= ubertooth-dfu
 
 # Define Messages
 # English


### PR DESCRIPTION
This results in a clearer error message if ubertooth-dfu is not found.