### PR TITLE
Add specan_ui version to fix error in new setuptools versions

### DIFF
--- a/host/python/specan_ui/CMakeLists.txt
+++ b/host/python/specan_ui/CMakeLists.txt
@@ -23,6 +23,8 @@ set(DEPS        ${CMAKE_CURRENT_SOURCE_DIR}/specan/__init__.py
                 ${CMAKE_CURRENT_SOURCE_DIR}/specan/Ubertooth.py)
 set(OUTPUT      ${CMAKE_CURRENT_BINARY_DIR}/build)
 
+set(PACKAGE_VERSION 1)
+
 configure_file(${SETUP_PY_IN} ${SETUP_PY})
 
 add_custom_command(OUTPUT ${OUTPUT}/timestamp

--- a/host/python/specan_ui/setup.py
+++ b/host/python/specan_ui/setup.py
@@ -18,7 +18,7 @@ setup(
     author      = "Jared Boone, Michael Ossmann, Dominic Spill",
     url         = "https://github.com/greatscottgadgets/ubertooth/",
     license     = "GPL",
-    version     = '',
+    version     = '1',
     packages    = ['specan'],
     scripts     = ['ubertooth-specan-ui'],
     classifiers=[


### PR DESCRIPTION
There seems to be an error when building on later versions of setuptools caused by the fact that the package version is currently empty. This PR just adds a version of 1 to work around the error