### PR TITLE
Improved Paging process, speed and reliability

### DIFF
--- a/firmware/btbr/include/ubtbr/btphy.h
+++ b/firmware/btbr/include/ubtbr/btphy.h
@@ -19,6 +19,7 @@
 typedef enum btphy_mode_e {
 	BT_MODE_INQUIRY,
 	BT_MODE_PAGING,
+	BT_MODE_PAGING_RESPONSE,
 	BT_MODE_INQUIRY_SCAN,
 	BT_MODE_PAGE_SCAN,
 	BT_MODE_MASTER,
@@ -70,5 +71,10 @@ uint8_t btphy_whiten_seed(uint32_t clk);
 void btphy_adj_clkn_delay(int delay);
 void btphy_cancel_clkn_delay(void);
 void btphy_timer_add(uint32_t instant, btphy_timer_fn_t cb, void *cb_arg, uint8_t anyway);
+
+static inline void btphy_set_mode_no_ap(btphy_mode_t mode)
+{
+	btphy.mode = mode;
+}
 
 #endif

--- a/firmware/btbr/include/ubtbr/hop.h
+++ b/firmware/btbr/include/ubtbr/hop.h
@@ -37,6 +37,49 @@ static inline uint8_t perm5(uint8_t z, uint8_t p_high, uint16_t p_low)
 	return z;
 }
 
+
+/* This function computes the input value X to be sent to hop_selection_kernel when the master
+has clock clk, during page scan.
+
+A slave in PAGE_SCAN mode listens for ID(1) messages for a duration of PAGE_WINDOW (>=10ms)
+every PAGE_INTERVAL (either 0s, 1.28s or 2.56s), with slow frequency-hopping that only
+changes every 1.28s. The used frequency is calculated by hop_selection_kernel from the slave's
+BT-MAC (inputs A,B,C,D,E,F) and CLK[12:16] (input X).
+
+To establish connection the master must send ID(1) on the correct frequency.
+Knowing the slave BT-MAC (but not its CLK), the master needs to try all possible X values (2**5 = 32 options).
+On every master slot, the master tries two frequencies corresponding to two guesses for X (slave CLK[12:16]),
+one try on each clock of the slot. If any of them is correct, the slave will respond with ID(2)
+on the corresponding clock of the following slot.
+
+Since PAGE_WINDOW might be as short as 10ms, only 16 X values might fit a single window.
+For slaves whose PAGE_INTERVAL is long (1.28s or 2.56s), CLK[12:16] will change across windows.
+We want to avoid trying X values that correspond to the same guess for the slave's clock,
+i.e., if X was rejected on time T, then X+1 will be rejected on T+1.28s, X+2 will be rejected on T+2.56s, etc.
+Therefore we calculate a series of X values to try on each master clock (keeping in mind only
+even slots are the master's), in a way that:
+
+1. all possible X values are tried repeatedly within a 1.28s interval;
+2. if the 16 values tried during the 10ms window starting at time T were (X0,...,X15), then none of the values (X0+1,...,X15+1) will be tried on time T+1.28s;
+3. if the 16 values tried during the 10ms window starting at time T were (X0,...,X15), then none of the values (X0+2,...,X15+2) will be tried on time T+2.56s.
+
+* CLK[5:2,0] is a simple incrementing counter (jumping over slave slots indicated by CLK[1]==1) to satisfy (1);
+* CLK[16:12]*17 ensures adding 17 every 1.28s to satisfy (2);
+* CLK[16:13]*16 ensures adding 17+17+16=50 == 18 (mod 32) every 2.56s to satisfy (3). */
+inline uint8_t calc_iterate_slave_page_scan_phase(uint32_t clk)
+{
+	// 	X = ( CLK[5...2,0] + CLK[16...12]*17 + CLK[16...13]*16 ) mod 32
+	return ((((clk>>1) & 0x1e) | (clk&1) ) + ((clk>>12)&0x1f)*17 + ((clk>>13)&0xf)*16)%32  ;
+}
+
+/* When we recive an ID(1) acknoledgment, that is, ID(2) From the slave device we transition into PAGE_RESPONSE
+we freeze this value and use a frozen value of this +N (see Master Page Response Substate hopping scheme control word)
+("our" N is actually hop_state.x which is also used in bbcodec) */
+inline void hop_freeze_clock(uint32_t clk)
+{
+	hop_state.x = calc_iterate_slave_page_scan_phase(clk);
+}
+
 /* This function increment the x variable of for paging/inquiry hopping.
  * It must be called before each master's transmission. */
 static inline void hop_increment(void)

--- a/firmware/btbr/src/btphy/btphy.c
+++ b/firmware/btbr/src/btphy/btphy.c
@@ -222,6 +222,7 @@ uint8_t btphy_whiten_seed(uint32_t clk)
 	{
 	case BT_MODE_INQUIRY:
 	case BT_MODE_PAGING:
+	case BT_MODE_PAGING_RESPONSE:
 	case BT_MODE_INQUIRY_SCAN:
 	case BT_MODE_PAGE_SCAN:
 	/* BT 5.1|Vol 2, Part B, 7.2 :
@@ -260,7 +261,7 @@ void btphy_set_mode(btphy_mode_t mode, uint32_t lap, uint8_t uap)
 	/* BT Core Spec v5.2|Vol 2, Part B, table 2.3:
 	 * A23_0=lap, and A27_24=uap3_0 */
 	hop_init(lap|(uap<<24));
-	btphy.mode = mode;
+	btphy_set_mode_no_ap(mode);
 }
 
 void btphy_set_bdaddr(uint64_t bdaddr)


### PR DESCRIPTION
This PR improves the reliability and performance of the PAGING process when connecting to another Bluetooth device. This is done by 3 parts

1. Sending the page/`ID(1)` message 2 times within each master's tx window instead of once
2. Change the frequency iteration logic to, hopefully improve performance for devices that are not continually scanning. I.E. Their `SR/scan repetition` might be `R1`, `R2`
3. Implemented the logic in which if we "hit" the right frequency once, but failed to complete the process (receive `ID(3)`) retry for the time period given in the Bluetooth spec before giving up and continue to iterate other phases of the clock.